### PR TITLE
Add rule-based PDF extraction with Tabula

### DIFF
--- a/.github/workflows/rule-based-extract.yml
+++ b/.github/workflows/rule-based-extract.yml
@@ -1,0 +1,116 @@
+name: Rule-Based Extraction from WHO PDF
+
+on:
+  workflow_run:
+    workflows: ["Download Latest WHO PDF"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      week_number:
+        description: 'Week number to extract (leave empty for latest)'
+        required: false
+        type: string
+        default: ''
+      year:
+        description: 'Year (required if week specified)'
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  extract:
+    runs-on: ubuntu-latest
+    # Only run if the download workflow succeeded
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Install system dependencies (Java for Tabula)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y default-jre
+          java -version
+
+      - name: Install dependencies
+        run: |
+          # Install full project dependencies (includes tabula-py)
+          uv sync --frozen
+
+      - name: Run rule-based extraction
+        env:
+          DSCI_AZ_BLOB_DEV_SAS: ${{ secrets.DSCI_AZ_BLOB_DEV_SAS_WRITE }}
+          DSCI_AZ_BLOB_DEV_SAS_WRITE: ${{ secrets.DSCI_AZ_BLOB_DEV_SAS_WRITE }}
+          STAGE: dev
+          PYTHONUNBUFFERED: 1  # Force unbuffered output for real-time logs
+        run: |
+          # Build arguments
+          ARGS=""
+
+          # Week argument
+          if [ -n "${{ inputs.week_number }}" ]; then
+            ARGS="$ARGS --week ${{ inputs.week_number }}"
+          else
+            ARGS="$ARGS --week latest"
+          fi
+
+          # Year argument (if week specified)
+          if [ -n "${{ inputs.year }}" ]; then
+            ARGS="$ARGS --year ${{ inputs.year }}"
+          fi
+
+          # Run extraction
+          uv run python scripts/run_rule_based_extraction_gha.py $ARGS
+
+      - name: Create job summary
+        if: success()
+        run: |
+          echo "## Rule-Based Extraction Successful! ✅" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Details" >> $GITHUB_STEP_SUMMARY
+          echo "- **Week**: ${{ inputs.week_number || 'latest' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Method**: Tabula (lattice detection)" >> $GITHUB_STEP_SUMMARY
+          echo "- **Stage**: dev" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Outputs" >> $GITHUB_STEP_SUMMARY
+          echo "- 📊 Logs uploaded to: \`ds-cholera-pdf-scraper/processed/logs/rule_based_extraction_log.jsonl\`" >> $GITHUB_STEP_SUMMARY
+          echo "- 📄 CSV uploaded to: \`ds-cholera-pdf-scraper/processed/rule_based_extractions/\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Key Benefits" >> $GITHUB_STEP_SUMMARY
+          echo "- ⚡ **Fast**: No API calls, pure table detection" >> $GITHUB_STEP_SUMMARY
+          echo "- 💰 **Free**: No LLM API costs" >> $GITHUB_STEP_SUMMARY
+          echo "- 🎯 **Deterministic**: Same input = same output" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Comparison with LLM Extraction" >> $GITHUB_STEP_SUMMARY
+          echo "You can compare results with LLM extraction by querying both datasets:" >> $GITHUB_STEP_SUMMARY
+          echo '```python' >> $GITHUB_STEP_SUMMARY
+          echo '# Rule-based results' >> $GITHUB_STEP_SUMMARY
+          echo 'df_rule = pd.read_csv("processed/rule_based_extractions/OEW42-2025_rule-based_*.csv")' >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo '# LLM results' >> $GITHUB_STEP_SUMMARY
+          echo 'df_llm = pd.read_csv("processed/llm_extractions/OEW42-2025_gpt-5_*.csv")' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Handle failure
+        if: failure()
+        run: |
+          echo "## Rule-Based Extraction Failed ❌" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Check the logs above for error details." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Common Issues" >> $GITHUB_STEP_SUMMARY
+          echo "- Java not installed (required for Tabula)" >> $GITHUB_STEP_SUMMARY
+          echo "- PDF format changed (Tabula is sensitive to table structure)" >> $GITHUB_STEP_SUMMARY
+          echo "- Blob storage connection issues" >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,5 @@ tmp/
 /show_*.py
 /model_*.ipynb
 /extracted_*.txt
+
+exploration/kenny/

--- a/docs/rule-based-extraction.md
+++ b/docs/rule-based-extraction.md
@@ -1,0 +1,235 @@
+# Rule-Based PDF Table Extraction
+
+## Overview
+
+This project now supports **two extraction methods** for WHO cholera surveillance PDFs:
+
+1. **LLM-Based Extraction** (existing): Uses OpenAI vision models to extract table data
+2. **Rule-Based Extraction** (new): Uses Tabula for deterministic table detection
+
+## Rule-Based Extraction Architecture
+
+### Components
+
+#### 1. `src/rule_based_extract.py`
+Core extraction module using Tabula-Java for table detection.
+
+**Key Functions:**
+- `extract_table_from_pdf()`: Main API for extracting outbreak data
+- `find_table_pages()`: Locates table section using text search
+- `extract_raw_table()`: Uses Tabula with lattice mode
+- `clean_data()`: Standardizes numeric fields and adds metadata
+- `calculate_kpis()`: Computes week-over-week case changes
+
+**Example Usage:**
+```python
+from src.rule_based_extract import extract_table_from_pdf
+
+df = extract_table_from_pdf(
+    pdf_path="OEW42-2025.pdf",
+    week=42,
+    year=2025
+)
+print(f"Extracted {len(df)} outbreak records")
+```
+
+#### 2. `scripts/run_rule_based_extraction_gha.py`
+GitHub Actions wrapper script that:
+- Downloads PDFs from Azure Blob Storage
+- Runs rule-based extraction
+- Uploads results and logs to blob
+
+#### 3. `.github/workflows/rule-based-extract.yml`
+GitHub Actions workflow that:
+- Installs Java (required for Tabula)
+- Runs extraction on latest or specific week
+- Creates detailed job summaries
+
+## Comparison: Rule-Based vs LLM-Based
+
+| Aspect | Rule-Based (Tabula) | LLM-Based (GPT-5) |
+|--------|---------------------|-------------------|
+| **Speed** | ⚡ Fast (~5-10 seconds) | 🐢 Slower (~30-60 seconds) |
+| **Cost** | 💰 Free | 💸 Per-API-call cost |
+| **Accuracy** | 📊 Good for well-structured tables | 🎯 Better for complex/varied formats |
+| **Robustness** | ⚠️ Brittle (fails if PDF format changes) | ✅ Flexible (adapts to format variations) |
+| **Dependencies** | ☕ Requires Java + Tabula | 🔑 Requires OpenAI API key |
+| **Maintenance** | 🔧 Requires updates if WHO changes PDF format | 🤖 Self-adapting with prompt updates |
+
+## When to Use Each Method
+
+### Use Rule-Based Extraction When:
+- ✅ PDF format is consistent and stable
+- ✅ Tables have clear borders (lattice structure)
+- ✅ Cost optimization is important
+- ✅ Speed is critical
+- ✅ Deterministic results are required
+
+### Use LLM-Based Extraction When:
+- ✅ PDF format varies or changes frequently
+- ✅ Tables have complex layouts or merged cells
+- ✅ Manual corrections are embedded in PDFs
+- ✅ Flexibility is more important than speed
+- ✅ You need to extract unstructured notes/context
+
+## Running Extractions
+
+### GitHub Actions (Automated)
+
+#### Latest Week:
+```yaml
+# Trigger manually with defaults
+workflow_dispatch: rule-based-extract.yml
+```
+
+#### Specific Week:
+```yaml
+# Trigger manually with inputs
+workflow_dispatch: rule-based-extract.yml
+  week_number: "42"
+  year: "2025"
+```
+
+### Local Development
+
+#### Install Dependencies:
+```bash
+# Install Java (required for Tabula)
+# macOS
+brew install openjdk
+
+# Ubuntu/Debian
+sudo apt-get install default-jre
+
+# Install Python dependencies
+uv sync
+```
+
+#### Run Extraction:
+```python
+from src.rule_based_extract import extract_table_from_pdf
+
+# Extract from local PDF
+df = extract_table_from_pdf(
+    pdf_path="path/to/OEW42-2025.pdf",
+    week=42,
+    year=2025
+)
+
+# Save results
+df.to_csv("extracted_data.csv", index=False)
+print(f"Extracted {len(df)} records")
+```
+
+## Blob Storage Structure
+
+### Inputs (Raw PDFs):
+```
+ds-cholera-pdf-scraper/
+  raw/
+    monitoring/
+      OEW42-2025.pdf
+      OEW43-2025.pdf
+      ...
+```
+
+### Outputs (Extracted Data):
+```
+ds-cholera-pdf-scraper/
+  processed/
+    rule_based_extractions/
+      OEW42-2025_rule-based_1729468934.csv
+      OEW43-2025_rule-based_1729555334.csv
+      ...
+    llm_extractions/
+      OEW42-2025_gpt-5_1729468934.csv
+      OEW43-2025_gpt-5_1729555334.csv
+      ...
+    logs/
+      rule_based_extraction_log.jsonl
+      prompt_logs/
+        run_1729468934.parquet
+        ...
+```
+
+## Execution Logs
+
+Rule-based extractions are logged in JSONL format:
+
+```json
+{
+  "week": 42,
+  "year": 2025,
+  "pdf_name": "OEW42-2025.pdf",
+  "run_date": "2025-10-20T14:32:14",
+  "status": "success",
+  "extraction_method": "rule-based-tabula",
+  "records_extracted": 45,
+  "execution_time_seconds": 8.23,
+  "runner": "github-actions",
+  "blob_uploaded": true,
+  "csv_blob_path": "ds-cholera-pdf-scraper/processed/rule_based_extractions/OEW42-2025_rule-based_1729468934.csv"
+}
+```
+
+## Comparing Extraction Methods
+
+You can compare results from both methods using blob storage queries:
+
+```python
+import pandas as pd
+from azure.storage.blob import BlobServiceClient
+
+# Download both extractions
+df_rule = pd.read_csv("processed/rule_based_extractions/OEW42-2025_rule-based_*.csv")
+df_llm = pd.read_csv("processed/llm_extractions/OEW42-2025_gpt-5_*.csv")
+
+# Compare record counts
+print(f"Rule-based: {len(df_rule)} records")
+print(f"LLM-based: {len(df_llm)} records")
+
+# Compare specific fields
+comparison = pd.merge(
+    df_rule[['Country', 'Event', 'Total cases']],
+    df_llm[['Country', 'Event', 'Total cases']],
+    on=['Country', 'Event'],
+    suffixes=('_rule', '_llm')
+)
+
+# Find discrepancies
+discrepancies = comparison[comparison['Total cases_rule'] != comparison['Total cases_llm']]
+print(f"Discrepancies: {len(discrepancies)} records")
+```
+
+## Troubleshooting
+
+### Java Not Found
+```bash
+# Install Java
+sudo apt-get install default-jre
+
+# Verify installation
+java -version
+```
+
+### Tabula Extraction Fails
+- **Check PDF structure**: Tabula requires tables with clear borders
+- **Inspect page range**: Verify "All events currently being monitored" text exists
+- **Try LLM extraction**: May be more robust for complex formats
+
+### No Data Extracted
+- **Check logs**: Look for PyPDF2 or Tabula errors
+- **Verify PDF validity**: Ensure PDF is not corrupted
+- **Check page numbers**: Table detection may have failed
+
+## Future Improvements
+
+1. **Hybrid Approach**: Use rule-based as primary, LLM as fallback
+2. **Quality Scoring**: Automatically assess extraction quality
+3. **Diff Analysis**: Automated comparison between methods
+4. **OCR Fallback**: Handle scanned/image-based PDFs
+5. **Historical Validation**: Cross-check against previous weeks
+
+## Credits
+
+Rule-based extraction logic adapted from Kenny's original implementation with enhancements for cloud-native deployment and blob storage integration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "selenium>=4.0.0",
     "PyPDF2>=3.0.0",
     "pdfplumber>=0.11.0",
+    "tabula-py>=2.9.0",  # Rule-based table extraction (requires Java)
 
     # Data processing
     "pandas>=2.0.0",

--- a/scripts/run_rule_based_extraction_gha.py
+++ b/scripts/run_rule_based_extraction_gha.py
@@ -1,0 +1,529 @@
+#!/usr/bin/env python3
+"""
+GitHub Actions wrapper for rule-based (Tabula) extraction from WHO cholera PDFs.
+
+This script runs in GitHub Actions to:
+1. Download the latest PDF from Azure Blob Storage
+2. Run rule-based table extraction using Tabula
+3. Log results to JSONL
+4. Upload extracted data and logs back to blob
+
+Usage:
+    # Extract from latest PDF in blob
+    python scripts/run_rule_based_extraction_gha.py --week latest
+
+    # Extract from specific week
+    python scripts/run_rule_based_extraction_gha.py --week 42 --year 2025
+
+Environment variables required:
+    DSCI_AZ_BLOB_DEV_SAS_WRITE: Azure Blob SAS token
+    STAGE: dev or prod (default: dev)
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+import tempfile
+import time
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Optional, Dict, Any
+
+import ocha_stratus as stratus
+import pandas as pd
+from azure.storage.blob import BlobServiceClient
+
+from src.config import Config
+from src.rule_based_extract import extract_table_from_pdf
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ExtractionRunMetadata:
+    """Metadata about an extraction run execution."""
+    # Bulletin info
+    week: Optional[int]
+    year: Optional[int]
+    pdf_name: str
+
+    # Run context
+    run_date: str
+    status: str  # "success" or "failed"
+    error_message: Optional[str]
+    runner: str  # "github-actions" or "local"
+    trigger: Optional[str]  # "schedule", "workflow_dispatch", etc.
+    run_id: Optional[str]
+    run_url: Optional[str]
+
+    # Extraction details
+    extraction_method: str  # "rule-based-tabula"
+    records_extracted: int
+    execution_time_seconds: float
+
+    # Outcome
+    blob_uploaded: bool
+    csv_blob_path: Optional[str]
+    log_blob_path: Optional[str]
+
+    def to_dict(self) -> Dict:
+        """Convert to dictionary."""
+        return asdict(self)
+
+    def to_jsonl(self) -> str:
+        """Convert to JSONL format (single line JSON)."""
+        return json.dumps(self.to_dict())
+
+
+def get_run_context() -> Dict[str, Optional[str]]:
+    """
+    Detect execution context (GitHub Actions vs local).
+
+    Returns dict with runner, run_id, run_url, and trigger.
+    """
+    github_run_id = os.getenv("GITHUB_RUN_ID")
+
+    if github_run_id:
+        github_repo = os.getenv("GITHUB_REPOSITORY", "unknown/unknown")
+        return {
+            "runner": "github-actions",
+            "run_id": github_run_id,
+            "run_url": f"https://github.com/{github_repo}/actions/runs/{github_run_id}",
+            "trigger": os.getenv("GITHUB_EVENT_NAME"),
+        }
+    else:
+        return {
+            "runner": "local",
+            "run_id": None,
+            "run_url": None,
+            "trigger": None,
+        }
+
+
+def get_latest_pdf_from_blob(stage: str = "dev") -> Optional[Dict[str, Any]]:
+    """
+    Get the latest PDF from Azure Blob Storage.
+
+    Returns:
+        Dict with blob_name, filename, week, year, or None if not found
+    """
+    container = Config.BLOB_CONTAINER
+    proj_dir = Config.BLOB_PROJ_DIR
+
+    print("🔍 Looking for latest PDF in blob storage...")
+
+    try:
+        # Get SAS token
+        sas_token = os.getenv(f"DSCI_AZ_BLOB_{stage.upper()}_SAS_WRITE")
+        if not sas_token:
+            print(f"❌ No SAS token found for stage {stage}")
+            return None
+
+        # Connect to blob
+        account_url = f"https://imb0chd0{stage}.blob.core.windows.net"
+        blob_service_client = BlobServiceClient(account_url=account_url, credential=sas_token)
+        container_client = blob_service_client.get_container_client(container)
+
+        # List blobs in monitoring directory
+        blob_prefix = f"{proj_dir}/raw/monitoring/"
+        blobs = list(container_client.list_blobs(name_starts_with=blob_prefix))
+
+        # Filter for PDF files
+        pdf_blobs = [b for b in blobs if b.name.endswith('.pdf')]
+
+        if not pdf_blobs:
+            print("❌ No PDFs found in blob storage")
+            return None
+
+        # Sort by last_modified (most recent first)
+        pdf_blobs.sort(key=lambda x: x.last_modified, reverse=True)
+        latest_blob = pdf_blobs[0]
+
+        # Extract week/year from filename (format: OEW42-2025.pdf)
+        import re
+        filename = Path(latest_blob.name).name
+        match = re.match(r'OEW(\d+)-(\d{4})\.pdf', filename)
+
+        if match:
+            week = int(match.group(1))
+            year = int(match.group(2))
+        else:
+            week = None
+            year = None
+
+        print(f"✅ Found latest PDF: {filename}")
+        if week and year:
+            print(f"   Week {week}, Year {year}")
+
+        return {
+            'blob_name': latest_blob.name,
+            'filename': filename,
+            'week': week,
+            'year': year,
+            'last_modified': latest_blob.last_modified,
+        }
+
+    except Exception as e:
+        print(f"❌ Error listing blobs: {e}")
+        return None
+
+
+def download_pdf_from_blob(blob_name: str, local_path: Path, stage: str = "dev") -> bool:
+    """
+    Download a PDF from Azure Blob Storage.
+
+    Args:
+        blob_name: Full blob path
+        local_path: Local path to save the PDF
+        stage: Azure stage (dev/prod)
+
+    Returns:
+        True if successful, False otherwise
+    """
+    try:
+        print(f"📥 Downloading PDF from blob...")
+
+        # Use stratus to download
+        blob_data = stratus.load_blob_data(
+            blob_name=blob_name,
+            stage=stage,
+            container_name=Config.BLOB_CONTAINER,
+        )
+
+        # Write to local file
+        with open(local_path, 'wb') as f:
+            f.write(blob_data)
+
+        # Verify file size
+        file_size = local_path.stat().st_size / 1024 / 1024  # MB
+        print(f"✅ Downloaded {local_path.name} ({file_size:.2f} MB)")
+
+        return True
+
+    except Exception as e:
+        print(f"❌ Error downloading PDF: {e}")
+        return False
+
+
+def upload_csv_to_blob(
+    csv_path: Path,
+    pdf_name: str,
+    timestamp: int,
+    stage: str = "dev"
+) -> Optional[str]:
+    """
+    Upload extracted CSV to Azure Blob Storage.
+
+    Args:
+        csv_path: Local path to CSV file
+        pdf_name: Name of the PDF (e.g., "OEW42-2025.pdf")
+        timestamp: Timestamp for filename
+        stage: Azure stage (dev/prod)
+
+    Returns:
+        Blob path if successful, None otherwise
+    """
+    try:
+        proj_dir = Config.BLOB_PROJ_DIR
+
+        # Create filename: <pdf_stem>_rule-based_<timestamp>.csv
+        pdf_stem = Path(pdf_name).stem
+        new_filename = f"{pdf_stem}_rule-based_{timestamp}.csv"
+
+        # Upload to processed/rule_based_extractions/
+        blob_path = f"{proj_dir}/processed/rule_based_extractions/{new_filename}"
+
+        print(f"📤 Uploading extraction CSV to blob...")
+        print(f"   Filename: {new_filename}")
+
+        # Read CSV as DataFrame
+        df = pd.read_csv(csv_path)
+
+        # Upload using stratus
+        stratus.upload_csv_to_blob(
+            df=df,
+            blob_name=blob_path,
+            stage=stage,
+            container_name=Config.BLOB_CONTAINER,
+        )
+
+        print(f"✅ Uploaded to {blob_path}")
+
+        return blob_path
+
+    except Exception as e:
+        print(f"❌ Error uploading CSV: {e}")
+        return None
+
+
+def upload_log_to_blob(log_path: Path, stage: str = "dev") -> Optional[str]:
+    """
+    Upload JSONL log file to Azure Blob Storage.
+
+    Args:
+        log_path: Local path to JSONL log
+        stage: Azure stage (dev/prod)
+
+    Returns:
+        Blob path if successful, None otherwise
+    """
+    try:
+        proj_dir = Config.BLOB_PROJ_DIR
+        blob_path = f"{proj_dir}/processed/logs/rule_based_extraction_log.jsonl"
+
+        print(f"📤 Uploading execution log to blob...")
+
+        with open(log_path, "rb") as f:
+            stratus.upload_blob_data(
+                data=f,
+                blob_name=blob_path,
+                stage=stage,
+                container_name=Config.BLOB_CONTAINER,
+                content_type="application/x-ndjson",
+            )
+
+        print(f"✅ Uploaded log to {blob_path}")
+
+        return blob_path
+
+    except Exception as e:
+        print(f"❌ Error uploading log: {e}")
+        return None
+
+
+def download_log_from_blob(local_path: Path, stage: str = "dev") -> bool:
+    """
+    Download existing log file from blob storage.
+
+    Args:
+        local_path: Local path to save log
+        stage: Azure stage
+
+    Returns:
+        True if successful, False otherwise
+    """
+    proj_dir = Config.BLOB_PROJ_DIR
+    blob_path = f"{proj_dir}/processed/logs/rule_based_extraction_log.jsonl"
+
+    try:
+        print(f"📥 Downloading existing log from blob...")
+        blob_data = stratus.load_blob_data(
+            blob_name=blob_path,
+            stage=stage,
+            container_name=Config.BLOB_CONTAINER,
+        )
+        with open(local_path, 'wb') as f:
+            f.write(blob_data)
+        print(f"✅ Downloaded existing log")
+        return True
+    except Exception:
+        print("ℹ️  No existing log found (this is normal for first run)")
+        return False
+
+
+def main():
+    """Main execution function."""
+    parser = argparse.ArgumentParser(
+        description="Run rule-based extraction in GitHub Actions"
+    )
+    parser.add_argument(
+        "--week",
+        type=str,
+        default="latest",
+        help="Week number or 'latest' (default: latest)"
+    )
+    parser.add_argument(
+        "--year",
+        type=int,
+        help="Year (required if week is specified)"
+    )
+
+    args = parser.parse_args()
+
+    # Get environment
+    stage = os.getenv("STAGE", "dev")
+
+    print("=" * 60)
+    print("GitHub Actions Rule-Based Extraction Workflow")
+    print("=" * 60)
+    print(f"Stage: {stage}")
+    print(f"Week: {args.week}")
+    if args.year:
+        print(f"Year: {args.year}")
+    print()
+
+    # Get run context
+    run_context = get_run_context()
+    start_time = time.time()
+    run_date = datetime.now().isoformat()
+    timestamp = int(time.time())
+
+    # Initialize run metadata
+    run_metadata = None
+    pdf_info = None
+
+    # Create temp directory
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        try:
+            # Step 1: Get PDF from blob
+            if args.week == "latest":
+                pdf_info = get_latest_pdf_from_blob(stage=stage)
+                if not pdf_info:
+                    raise Exception("No PDF found in blob storage")
+
+                blob_name = pdf_info['blob_name']
+                filename = pdf_info['filename']
+                week = pdf_info['week']
+                year = pdf_info['year']
+            else:
+                # Construct blob name from week/year
+                if not args.year:
+                    raise Exception("--year is required when --week is specified")
+
+                week = int(args.week)
+                year = args.year
+                filename = f"OEW{week:02d}-{year}.pdf"
+                blob_name = f"{Config.BLOB_PROJ_DIR}/raw/monitoring/{filename}"
+                pdf_info = {
+                    'blob_name': blob_name,
+                    'filename': filename,
+                    'week': week,
+                    'year': year,
+                }
+
+            # Step 2: Download PDF
+            local_pdf_path = temp_path / filename
+            if not download_pdf_from_blob(blob_name, local_pdf_path, stage=stage):
+                raise Exception("Failed to download PDF")
+
+            print()
+
+            # Step 3: Run extraction
+            print("=" * 60)
+            print("🤖 Running Rule-Based Extraction (Tabula)")
+            print("=" * 60)
+            print(f"PDF: {filename}")
+            print(f"Week: {week}, Year: {year}")
+            print()
+
+            df = extract_table_from_pdf(
+                pdf_path=local_pdf_path,
+                week=week,
+                year=year
+            )
+
+            execution_time = time.time() - start_time
+
+            print()
+            print("=" * 60)
+            print("✅ Extraction Complete")
+            print("=" * 60)
+            print(f"Records extracted: {len(df)}")
+            print(f"Execution time: {execution_time:.2f}s")
+            print()
+
+            # Step 4: Save CSV locally
+            csv_filename = f"extraction_{timestamp}_rule_based.csv"
+            csv_path = temp_path / csv_filename
+            df.to_csv(csv_path, index=False)
+            print(f"💾 Saved CSV: {csv_path.name}")
+
+            # Step 5: Upload CSV to blob
+            csv_blob_path = upload_csv_to_blob(
+                csv_path=csv_path,
+                pdf_name=filename,
+                timestamp=timestamp,
+                stage=stage
+            )
+
+            # Create success metadata
+            run_metadata = ExtractionRunMetadata(
+                week=week,
+                year=year,
+                pdf_name=filename,
+                run_date=run_date,
+                status="success",
+                error_message=None,
+                runner=run_context["runner"],
+                trigger=run_context["trigger"],
+                run_id=run_context["run_id"],
+                run_url=run_context["run_url"],
+                extraction_method="rule-based-tabula",
+                records_extracted=len(df),
+                execution_time_seconds=execution_time,
+                blob_uploaded=csv_blob_path is not None,
+                csv_blob_path=csv_blob_path,
+                log_blob_path=None,  # Will be set after log upload
+            )
+
+        except Exception as e:
+            execution_time = time.time() - start_time
+            print(f"❌ Extraction failed: {e}")
+            import traceback
+            traceback.print_exc()
+
+            # Create failed run metadata
+            run_metadata = ExtractionRunMetadata(
+                week=pdf_info['week'] if pdf_info else (int(args.week) if args.week != 'latest' else None),
+                year=pdf_info['year'] if pdf_info else args.year,
+                pdf_name=pdf_info['filename'] if pdf_info else f"OEW{args.week}-{args.year}.pdf",
+                run_date=run_date,
+                status="failed",
+                error_message=str(e),
+                runner=run_context["runner"],
+                trigger=run_context["trigger"],
+                run_id=run_context["run_id"],
+                run_url=run_context["run_url"],
+                extraction_method="rule-based-tabula",
+                records_extracted=0,
+                execution_time_seconds=execution_time,
+                blob_uploaded=False,
+                csv_blob_path=None,
+                log_blob_path=None,
+            )
+
+        finally:
+            # Step 6: Append to log and upload
+            if run_metadata:
+                # Download existing log
+                log_path = temp_path / "rule_based_extraction_log.jsonl"
+                download_log_from_blob(log_path, stage=stage)
+
+                # Append new run
+                with open(log_path, "a") as f:
+                    f.write(run_metadata.to_jsonl() + "\n")
+
+                # Upload log
+                log_blob_path = upload_log_to_blob(log_path, stage=stage)
+                run_metadata.log_blob_path = log_blob_path
+
+                print()
+                print("=" * 60)
+                if run_metadata.status == "success":
+                    print("✅ Workflow Complete!")
+                    print("=" * 60)
+                    print(f"PDF: {run_metadata.pdf_name}")
+                    print(f"Records: {run_metadata.records_extracted}")
+                    print(f"Time: {run_metadata.execution_time_seconds:.2f}s")
+                    print()
+                    print("📊 Files uploaded to blob:")
+                    print(f"   CSV: {run_metadata.csv_blob_path}")
+                    print(f"   Log: {run_metadata.log_blob_path}")
+                else:
+                    print("❌ Workflow Failed")
+                    print("=" * 60)
+                    print(f"Error: {run_metadata.error_message}")
+                    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rule_based_extract.py
+++ b/src/rule_based_extract.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""
+Rule-Based PDF Table Extraction Module
+
+This module provides table extraction using Tabula (lattice detection) instead of LLMs.
+Based on Kenny's approach but integrated with the existing codebase infrastructure.
+
+Key differences from LLM extraction:
+- Uses tabula-py for table detection (requires Java)
+- Deterministic and fast
+- No API costs
+- Brittle to PDF format changes
+
+Usage:
+    from src.rule_based_extract import extract_table_from_pdf
+
+    df = extract_table_from_pdf(
+        pdf_path="/path/to/OEW42-2025.pdf",
+        week=42,
+        year=2025
+    )
+"""
+
+import logging
+import re
+from pathlib import Path
+from typing import Optional, Tuple
+
+import pandas as pd
+import PyPDF2
+from tabula.io import convert_into
+
+logger = logging.getLogger(__name__)
+
+
+# Column names for WHO outbreak surveillance tables
+COLUMN_NAMES = [
+    'Country', 'Event', 'Grade', 'Date notified to WCO',
+    'Start of reporting period', 'End of reporting period',
+    'Total cases', 'Cases Confirmed', 'Deaths', 'CFR'
+]
+
+# CSV cleaning replacements (remove newlines from headers)
+CSV_REPLACEMENTS = {
+    "Date notified\nto WCO": "Date notified to WCO",
+    "Start of\nreporting\nperiod": "Start of reporting period",
+    "End of\nreporting\nperiod": "End of reporting period",
+    "Cases\nConfirmed": "Cases Confirmed"
+}
+
+
+def find_table_pages(pdf_path: Path) -> Tuple[int, int]:
+    """
+    Find the page range containing the outbreak surveillance table.
+
+    Searches for "All events currently being monitored" text to identify
+    the start of the table section.
+
+    Args:
+        pdf_path: Path to PDF file
+
+    Returns:
+        Tuple of (start_page, end_page) as 1-indexed page numbers
+    """
+    try:
+        pdf_reader = PyPDF2.PdfReader(str(pdf_path))
+        total_pages = len(pdf_reader.pages)
+        search_text = "All events currently being monitored"
+
+        start_page = total_pages  # Default to last page if not found
+        for i, page in enumerate(pdf_reader.pages):
+            text = page.extract_text()
+            if re.search(search_text, text, re.IGNORECASE):
+                start_page = i + 1  # 1-indexed
+                logger.info(f"Found table start at page {start_page}")
+                break
+
+        return start_page, total_pages
+
+    except Exception as e:
+        logger.error(f"Error finding table pages: {e}")
+        # Fallback: assume table starts at page 1
+        return 1, 1
+
+
+def extract_raw_table(pdf_path: Path, start_page: int, end_page: int) -> Optional[pd.DataFrame]:
+    """
+    Extract raw table data from PDF using Tabula.
+
+    Args:
+        pdf_path: Path to PDF file
+        start_page: Starting page (1-indexed)
+        end_page: Ending page (1-indexed)
+
+    Returns:
+        DataFrame with raw extracted data, or None if extraction fails
+    """
+    import tempfile
+
+    try:
+        logger.info(f"Extracting table from pages {start_page}-{end_page}")
+
+        # Create temporary CSV file
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False) as tmp_file:
+            tmp_csv_path = tmp_file.name
+
+        # Extract table using Tabula (lattice mode)
+        page_range = f"{start_page}-{end_page}"
+        convert_into(
+            str(pdf_path),
+            tmp_csv_path,
+            output_format="csv",
+            pages=page_range,
+            lattice=True  # Use lattice detection for bordered tables
+        )
+
+        # Read the extracted CSV
+        df = pd.read_csv(tmp_csv_path, encoding="ISO-8859-1")
+
+        # Clean up temp file
+        Path(tmp_csv_path).unlink(missing_ok=True)
+
+        logger.info(f"Extracted {len(df)} raw rows")
+        return df
+
+    except Exception as e:
+        logger.error(f"Error extracting table: {e}")
+        return None
+
+
+def clean_headers(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Clean column headers by removing newlines and normalizing names.
+
+    Args:
+        df: DataFrame with raw headers
+
+    Returns:
+        DataFrame with cleaned headers
+    """
+    # Apply replacements to column names
+    cleaned_columns = []
+    for col in df.columns:
+        col_str = str(col)
+        for old, new in CSV_REPLACEMENTS.items():
+            col_str = col_str.replace(old, new)
+        cleaned_columns.append(col_str)
+
+    df.columns = cleaned_columns
+
+    # Standardize to expected column names if possible
+    # This handles cases where Tabula extracted correct data but with slight variations
+    if len(df.columns) == len(COLUMN_NAMES):
+        df.columns = COLUMN_NAMES
+
+    return df
+
+
+def clean_data(df: pd.DataFrame, week: int, year: int) -> pd.DataFrame:
+    """
+    Clean and transform the extracted data.
+
+    Args:
+        df: Raw DataFrame from Tabula
+        week: Week number
+        year: Year
+
+    Returns:
+        Cleaned DataFrame with metadata columns
+    """
+    # Remove completely empty rows
+    df = df.dropna(how="all")
+
+    # Remove rows without a grade (filter out non-data rows)
+    if 'Grade' in df.columns:
+        df = df[df['Grade'].notna()]
+
+    # Clean text fields (remove newlines from country/event names)
+    if 'Country' in df.columns:
+        df['Country'] = df['Country'].str.replace("\n", " ", regex=False)
+        df['Country'] = df['Country'].str.strip()
+
+    if 'Event' in df.columns:
+        df['Event'] = df['Event'].str.replace("\n", " ", regex=False)
+        df['Event'] = df['Event'].str.strip()
+
+    # Clean numeric fields
+    if 'CFR' in df.columns:
+        df['CFR'] = (df['CFR'].astype(str)
+                     .str.replace("%", "", regex=False)
+                     .str.replace(",", ".", regex=False)
+                     .str.replace("-", "0", regex=False))
+
+    if 'Cases Confirmed' in df.columns:
+        df['Cases Confirmed'] = (df['Cases Confirmed'].astype(str)
+                                  .str.replace("-", "0", regex=False)
+                                  .str.replace(" ", "", regex=False)
+                                  .str.replace(",", "", regex=False))
+
+    if 'Total cases' in df.columns:
+        df['Total cases'] = (df['Total cases'].astype(str)
+                             .str.replace("-", "0", regex=False)
+                             .str.replace(" ", "", regex=False)
+                             .str.replace(",", "", regex=False))
+
+    if 'Deaths' in df.columns:
+        df['Deaths'] = (df['Deaths'].astype(str)
+                        .str.replace("-", "0", regex=False)
+                        .str.replace(" ", "", regex=False)
+                        .str.replace(",", "", regex=False))
+
+    # Add metadata columns
+    df['WeekNumber'] = week
+    df['Year'] = year
+    df['Month'] = week  # Simple approximation (can be improved with date mapping)
+
+    # Add source document
+    df['ExtractionMethod'] = 'rule-based-tabula'
+
+    logger.info(f"Cleaned data: {len(df)} rows")
+
+    return df
+
+
+def extract_table_from_pdf(
+    pdf_path: str | Path,
+    week: Optional[int] = None,
+    year: Optional[int] = None,
+) -> pd.DataFrame:
+    """
+    Main function to extract outbreak surveillance table from WHO PDF.
+
+    This is the high-level API that orchestrates the extraction pipeline:
+    1. Find table pages
+    2. Extract raw table with Tabula
+    3. Clean headers
+    4. Clean data
+
+    Args:
+        pdf_path: Path to PDF file
+        week: Week number (optional, for metadata)
+        year: Year (optional, for metadata)
+
+    Returns:
+        Cleaned DataFrame with extracted outbreak data
+
+    Raises:
+        ValueError: If extraction fails or produces no data
+
+    Example:
+        >>> df = extract_table_from_pdf("OEW42-2025.pdf", week=42, year=2025)
+        >>> print(f"Extracted {len(df)} outbreak records")
+    """
+    pdf_path = Path(pdf_path)
+
+    if not pdf_path.exists():
+        raise FileNotFoundError(f"PDF not found: {pdf_path}")
+
+    logger.info(f"Starting rule-based extraction: {pdf_path.name}")
+
+    # Extract week/year from filename if not provided (format: OEW42-2025.pdf)
+    if week is None or year is None:
+        filename_match = re.match(r'OEW(\d+)-(\d{4})\.pdf', pdf_path.name)
+        if filename_match:
+            week = week or int(filename_match.group(1))
+            year = year or int(filename_match.group(2))
+            logger.info(f"Extracted metadata from filename: Week {week}, Year {year}")
+
+    # Default values if still missing
+    week = week or 1
+    year = year or 2025
+
+    # Step 1: Find table pages
+    start_page, end_page = find_table_pages(pdf_path)
+
+    # Step 2: Extract raw table
+    df = extract_raw_table(pdf_path, start_page, end_page)
+
+    if df is None or len(df) == 0:
+        raise ValueError(f"Failed to extract any data from {pdf_path.name}")
+
+    # Step 3: Clean headers
+    df = clean_headers(df)
+
+    # Step 4: Clean data
+    df = clean_data(df, week, year)
+
+    logger.info(f"Extraction complete: {len(df)} records from {pdf_path.name}")
+
+    return df
+
+
+def calculate_kpis(df: pd.DataFrame, week_date_csv: Optional[Path] = None) -> pd.DataFrame:
+    """
+    Calculate KPIs from extracted data (case changes, etc.).
+
+    This is based on Kenny's calculateKPI.py logic.
+
+    Args:
+        df: DataFrame with extracted outbreak data
+        week_date_csv: Optional path to weekDate.csv for date mapping
+
+    Returns:
+        DataFrame with additional KPI columns
+    """
+    # Create YearWeek column
+    df['YearWeek'] = df['Year'].astype(str) + '-' + df['WeekNumber'].astype(str)
+
+    # Merge with week date mapping if provided
+    if week_date_csv and week_date_csv.exists():
+        weekdate_df = pd.read_csv(week_date_csv)
+        df = pd.merge(df, weekdate_df, on='YearWeek', how='left')
+
+        # Clean and parse WeekDate
+        if 'WeekDate' in df.columns:
+            df['WeekDate'] = df['WeekDate'].str.replace(" ", "", regex=False)
+            df['WeekDate'] = pd.to_datetime(df['WeekDate'], format='%m/%d/%Y', errors='coerce')
+
+    # Convert Total cases to numeric
+    if 'Total cases' in df.columns:
+        df['Total cases'] = df['Total cases'].str.replace('[ ,]', '', regex=True)
+        df['Total cases'] = pd.to_numeric(df['Total cases'], errors='coerce')
+
+    # Sort by date and country
+    sort_cols = ['WeekDate', 'Country', 'Event'] if 'WeekDate' in df.columns else ['Year', 'WeekNumber', 'Country', 'Event']
+    df = df.sort_values(sort_cols, ascending=True)
+
+    # Calculate case change (week-over-week difference by Country/Event)
+    df['Case Change'] = df.groupby(['Country', 'Event'])['Total cases'].diff()
+
+    # Trim whitespace from country names
+    if 'Country' in df.columns:
+        df['Country'] = df['Country'].str.strip()
+
+    # Handle long country names (preserve important ones like DRC)
+    long_country_mapping = {
+        'Democratic Republic of the Congo': 'Democratic Republic of the Congo',
+    }
+
+    for long_country, new_name in long_country_mapping.items():
+        df.loc[df['Country'] == long_country, 'Country'] = new_name
+
+    # Apply fallback for other long country names (>30 chars)
+    df.loc[
+        (df['Country'].str.len() > 30) &
+        (~df['Country'].isin(long_country_mapping.keys())),
+        'Country'
+    ] = "Cote d'Ivoire"
+
+    logger.info(f"KPI calculation complete: {len(df)} records")
+
+    return df

--- a/uv.lock
+++ b/uv.lock
@@ -356,6 +356,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "requests" },
     { name = "selenium" },
+    { name = "tabula-py" },
 ]
 
 [package.optional-dependencies]
@@ -393,6 +394,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.31.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "selenium", specifier = ">=4.0.0" },
+    { name = "tabula-py", specifier = ">=2.9.0" },
 ]
 provides-extras = ["dev"]
 
@@ -763,6 +765,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
     { url = "https://files.pythonhosted.org/packages/3f/c7/12381b18e21aef2c6bd3a636da1088b888b97b7a0362fac2e4de92405f97/greenlet-3.2.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:20fb936b4652b6e307b8f347665e2c615540d4b42b3b4c8a321d8286da7e520f", size = 1151142, upload-time = "2025-08-07T13:18:22.981Z" },
+    { url = "https://files.pythonhosted.org/packages/27/45/80935968b53cfd3f33cf99ea5f08227f2646e044568c9b1555b58ffd61c2/greenlet-3.2.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ee7a6ec486883397d70eec05059353b8e83eca9168b9f3f9a361971e77e0bcd0", size = 1564846, upload-time = "2025-11-04T12:42:15.191Z" },
+    { url = "https://files.pythonhosted.org/packages/69/02/b7c30e5e04752cb4db6202a3858b149c0710e5453b71a3b2aec5d78a1aab/greenlet-3.2.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:326d234cbf337c9c3def0676412eb7040a35a768efc92504b947b3e9cfc7543d", size = 1633814, upload-time = "2025-11-04T12:42:17.175Z" },
     { url = "https://files.pythonhosted.org/packages/e9/08/b0814846b79399e585f974bbeebf5580fbe59e258ea7be64d9dfb253c84f/greenlet-3.2.4-cp312-cp312-win_amd64.whl", hash = "sha256:a7d4e128405eea3814a12cc2605e0e6aedb4035bf32697f72deca74de4105e02", size = 299899, upload-time = "2025-08-07T13:38:53.448Z" },
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
@@ -772,6 +776,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
     { url = "https://files.pythonhosted.org/packages/a2/15/0d5e4e1a66fab130d98168fe984c509249c833c1a3c16806b90f253ce7b9/greenlet-3.2.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:d25c5091190f2dc0eaa3f950252122edbbadbb682aa7b1ef2f8af0f8c0afefae", size = 1149210, upload-time = "2025-08-07T13:18:24.072Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/53/f9c440463b3057485b8594d7a638bed53ba531165ef0ca0e6c364b5cc807/greenlet-3.2.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6e343822feb58ac4d0a1211bd9399de2b3a04963ddeec21530fc426cc121f19b", size = 1564759, upload-time = "2025-11-04T12:42:19.395Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e4/3bb4240abdd0a8d23f4f88adec746a3099f0d86bfedb623f063b2e3b4df0/greenlet-3.2.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ca7f6f1f2649b89ce02f6f229d7c19f680a6238af656f61e0115b24857917929", size = 1634288, upload-time = "2025-11-04T12:42:21.174Z" },
     { url = "https://files.pythonhosted.org/packages/0b/55/2321e43595e6801e105fcfdee02b34c0f996eb71e6ddffca6b10b7e1d771/greenlet-3.2.4-cp313-cp313-win_amd64.whl", hash = "sha256:554b03b6e73aaabec3745364d6239e9e012d64c68ccd0b8430c64ccc14939a8b", size = 299685, upload-time = "2025-08-07T13:24:38.824Z" },
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
@@ -779,6 +785,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
+    { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/da/343cd760ab2f92bac1845ca07ee3faea9fe52bee65f7bcb19f16ad7de08b/greenlet-3.2.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:015d48959d4add5d6c9f6c5210ee3803a830dce46356e3bc326d6776bde54681", size = 1680760, upload-time = "2025-11-04T12:42:25.341Z" },
     { url = "https://files.pythonhosted.org/packages/e3/a5/6ddab2b4c112be95601c13428db1d8b6608a8b6039816f2ba09c346c08fc/greenlet-3.2.4-cp314-cp314-win_amd64.whl", hash = "sha256:e37ab26028f12dbb0ff65f29a8d3d44a765c61e729647bf2ddfbbed621726f01", size = 303425, upload-time = "2025-08-07T13:32:27.59Z" },
 ]
 
@@ -1543,8 +1551,10 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2d/75/364847b879eb630b3ac8293798e380e441a957c53657995053c5ec39a316/psycopg2_binary-2.9.11-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ab8905b5dcb05bf3fb22e0cf90e10f469563486ffb6a96569e51f897c750a76a", size = 4411159, upload-time = "2025-10-10T11:12:00.49Z" },
     { url = "https://files.pythonhosted.org/packages/6f/a0/567f7ea38b6e1c62aafd58375665a547c00c608a471620c0edc364733e13/psycopg2_binary-2.9.11-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf940cd7e7fec19181fdbc29d76911741153d51cab52e5c21165f3262125685e", size = 4468234, upload-time = "2025-10-10T11:12:04.892Z" },
     { url = "https://files.pythonhosted.org/packages/30/da/4e42788fb811bbbfd7b7f045570c062f49e350e1d1f3df056c3fb5763353/psycopg2_binary-2.9.11-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa0f693d3c68ae925966f0b14b8edda71696608039f4ed61b1fe9ffa468d16db", size = 4166236, upload-time = "2025-10-10T11:12:11.674Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/94/c1777c355bc560992af848d98216148be5f1be001af06e06fc49cbded578/psycopg2_binary-2.9.11-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a1cf393f1cdaf6a9b57c0a719a1068ba1069f022a59b8b1fe44b006745b59757", size = 3983083, upload-time = "2025-10-30T02:55:15.73Z" },
     { url = "https://files.pythonhosted.org/packages/bd/42/c9a21edf0e3daa7825ed04a4a8588686c6c14904344344a039556d78aa58/psycopg2_binary-2.9.11-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ef7a6beb4beaa62f88592ccc65df20328029d721db309cb3250b0aae0fa146c3", size = 3652281, upload-time = "2025-10-10T11:12:17.713Z" },
     { url = "https://files.pythonhosted.org/packages/12/22/dedfbcfa97917982301496b6b5e5e6c5531d1f35dd2b488b08d1ebc52482/psycopg2_binary-2.9.11-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:31b32c457a6025e74d233957cc9736742ac5a6cb196c6b68499f6bb51390bd6a", size = 3298010, upload-time = "2025-10-10T11:12:22.671Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ea/d3390e6696276078bd01b2ece417deac954dfdd552d2edc3d03204416c0c/psycopg2_binary-2.9.11-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:edcb3aeb11cb4bf13a2af3c53a15b3d612edeb6409047ea0b5d6a21a9d744b34", size = 3044641, upload-time = "2025-10-30T02:55:19.929Z" },
     { url = "https://files.pythonhosted.org/packages/12/9a/0402ded6cbd321da0c0ba7d34dc12b29b14f5764c2fc10750daa38e825fc/psycopg2_binary-2.9.11-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:62b6d93d7c0b61a1dd6197d208ab613eb7dcfdcca0a49c42ceb082257991de9d", size = 3347940, upload-time = "2025-10-10T11:12:26.529Z" },
     { url = "https://files.pythonhosted.org/packages/b1/d2/99b55e85832ccde77b211738ff3925a5d73ad183c0b37bcbbe5a8ff04978/psycopg2_binary-2.9.11-cp312-cp312-win_amd64.whl", hash = "sha256:b33fabeb1fde21180479b2d4667e994de7bbf0eec22832ba5d9b5e4cf65b6c6d", size = 2714147, upload-time = "2025-10-10T11:12:29.535Z" },
     { url = "https://files.pythonhosted.org/packages/ff/a8/a2709681b3ac11b0b1786def10006b8995125ba268c9a54bea6f5ae8bd3e/psycopg2_binary-2.9.11-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b8fb3db325435d34235b044b199e56cdf9ff41223a4b9752e8576465170bb38c", size = 3756572, upload-time = "2025-10-10T11:12:32.873Z" },
@@ -1552,8 +1562,10 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/11/32/b2ffe8f3853c181e88f0a157c5fb4e383102238d73c52ac6d93a5c8bffe6/psycopg2_binary-2.9.11-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c55b385daa2f92cb64b12ec4536c66954ac53654c7f15a203578da4e78105c0", size = 4411242, upload-time = "2025-10-10T11:12:42.388Z" },
     { url = "https://files.pythonhosted.org/packages/10/04/6ca7477e6160ae258dc96f67c371157776564679aefd247b66f4661501a2/psycopg2_binary-2.9.11-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c0377174bf1dd416993d16edc15357f6eb17ac998244cca19bc67cdc0e2e5766", size = 4468258, upload-time = "2025-10-10T11:12:48.654Z" },
     { url = "https://files.pythonhosted.org/packages/3c/7e/6a1a38f86412df101435809f225d57c1a021307dd0689f7a5e7fe83588b1/psycopg2_binary-2.9.11-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5c6ff3335ce08c75afaed19e08699e8aacf95d4a260b495a4a8545244fe2ceb3", size = 4166295, upload-time = "2025-10-10T11:12:52.525Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7d/c07374c501b45f3579a9eb761cbf2604ddef3d96ad48679112c2c5aa9c25/psycopg2_binary-2.9.11-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:84011ba3109e06ac412f95399b704d3d6950e386b7994475b231cf61eec2fc1f", size = 3983133, upload-time = "2025-10-30T02:55:24.329Z" },
     { url = "https://files.pythonhosted.org/packages/82/56/993b7104cb8345ad7d4516538ccf8f0d0ac640b1ebd8c754a7b024e76878/psycopg2_binary-2.9.11-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ba34475ceb08cccbdd98f6b46916917ae6eeb92b5ae111df10b544c3a4621dc4", size = 3652383, upload-time = "2025-10-10T11:12:56.387Z" },
     { url = "https://files.pythonhosted.org/packages/2d/ac/eaeb6029362fd8d454a27374d84c6866c82c33bfc24587b4face5a8e43ef/psycopg2_binary-2.9.11-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b31e90fdd0f968c2de3b26ab014314fe814225b6c324f770952f7d38abf17e3c", size = 3298168, upload-time = "2025-10-10T11:13:00.403Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/39/50c3facc66bded9ada5cbc0de867499a703dc6bca6be03070b4e3b65da6c/psycopg2_binary-2.9.11-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:d526864e0f67f74937a8fce859bd56c979f5e2ec57ca7c627f5f1071ef7fee60", size = 3044712, upload-time = "2025-10-30T02:55:27.975Z" },
     { url = "https://files.pythonhosted.org/packages/9c/8e/b7de019a1f562f72ada81081a12823d3c1590bedc48d7d2559410a2763fe/psycopg2_binary-2.9.11-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:04195548662fa544626c8ea0f06561eb6203f1984ba5b4562764fbeb4c3d14b1", size = 3347549, upload-time = "2025-10-10T11:13:03.971Z" },
     { url = "https://files.pythonhosted.org/packages/80/2d/1bb683f64737bbb1f86c82b7359db1eb2be4e2c0c13b947f80efefa7d3e5/psycopg2_binary-2.9.11-cp313-cp313-win_amd64.whl", hash = "sha256:efff12b432179443f54e230fdf60de1f6cc726b6c832db8701227d089310e8aa", size = 2714215, upload-time = "2025-10-10T11:13:07.14Z" },
     { url = "https://files.pythonhosted.org/packages/64/12/93ef0098590cf51d9732b4f139533732565704f45bdc1ffa741b7c95fb54/psycopg2_binary-2.9.11-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:92e3b669236327083a2e33ccfa0d320dd01b9803b3e14dd986a4fc54aa00f4e1", size = 3756567, upload-time = "2025-10-10T11:13:11.885Z" },
@@ -1561,8 +1573,10 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/13/1e/98874ce72fd29cbde93209977b196a2edae03f8490d1bd8158e7f1daf3a0/psycopg2_binary-2.9.11-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b52a3f9bb540a3e4ec0f6ba6d31339727b2950c9772850d6545b7eae0b9d7c5", size = 4411646, upload-time = "2025-10-10T11:13:24.432Z" },
     { url = "https://files.pythonhosted.org/packages/5a/bd/a335ce6645334fb8d758cc358810defca14a1d19ffbc8a10bd38a2328565/psycopg2_binary-2.9.11-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:db4fd476874ccfdbb630a54426964959e58da4c61c9feba73e6094d51303d7d8", size = 4468701, upload-time = "2025-10-10T11:13:29.266Z" },
     { url = "https://files.pythonhosted.org/packages/44/d6/c8b4f53f34e295e45709b7568bf9b9407a612ea30387d35eb9fa84f269b4/psycopg2_binary-2.9.11-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:47f212c1d3be608a12937cc131bd85502954398aaa1320cb4c14421a0ffccf4c", size = 4166293, upload-time = "2025-10-10T11:13:33.336Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/e0/f8cc36eadd1b716ab36bb290618a3292e009867e5c97ce4aba908cb99644/psycopg2_binary-2.9.11-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e35b7abae2b0adab776add56111df1735ccc71406e56203515e228a8dc07089f", size = 3983184, upload-time = "2025-10-30T02:55:32.483Z" },
     { url = "https://files.pythonhosted.org/packages/53/3e/2a8fe18a4e61cfb3417da67b6318e12691772c0696d79434184a511906dc/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fcf21be3ce5f5659daefd2b3b3b6e4727b028221ddc94e6c1523425579664747", size = 3652650, upload-time = "2025-10-10T11:13:38.181Z" },
     { url = "https://files.pythonhosted.org/packages/76/36/03801461b31b29fe58d228c24388f999fe814dfc302856e0d17f97d7c54d/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:9bd81e64e8de111237737b29d68039b9c813bdf520156af36d26819c9a979e5f", size = 3298663, upload-time = "2025-10-10T11:13:44.878Z" },
+    { url = "https://files.pythonhosted.org/packages/97/77/21b0ea2e1a73aa5fa9222b2a6b8ba325c43c3a8d54272839c991f2345656/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:32770a4d666fbdafab017086655bcddab791d7cb260a16679cc5a7338b64343b", size = 3044737, upload-time = "2025-10-30T02:55:35.69Z" },
     { url = "https://files.pythonhosted.org/packages/67/69/f36abe5f118c1dca6d3726ceae164b9356985805480731ac6712a63f24f0/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c3cb3a676873d7506825221045bd70e0427c905b9c8ee8d6acd70cfcbd6e576d", size = 3347643, upload-time = "2025-10-10T11:13:53.499Z" },
     { url = "https://files.pythonhosted.org/packages/e1/36/9c0c326fe3a4227953dfb29f5d0c8ae3b8eb8c1cd2967aa569f50cb3c61f/psycopg2_binary-2.9.11-cp314-cp314-win_amd64.whl", hash = "sha256:4012c9c954dfaccd28f94e84ab9f94e12df76b4afb22331b1f0d3154893a6316", size = 2803913, upload-time = "2025-10-10T11:13:57.058Z" },
 ]
@@ -2153,6 +2167,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/32/d5/0e66097fc64fa266f29a7963296b40a80d6a997b7ac13806183700676f86/sqlalchemy-2.0.44-cp313-cp313-win32.whl", hash = "sha256:ee51625c2d51f8baadf2829fae817ad0b66b140573939dd69284d2ba3553ae73", size = 2101275, upload-time = "2025-10-10T15:03:26.096Z" },
     { url = "https://files.pythonhosted.org/packages/03/51/665617fe4f8c6450f42a6d8d69243f9420f5677395572c2fe9d21b493b7b/sqlalchemy-2.0.44-cp313-cp313-win_amd64.whl", hash = "sha256:c1c80faaee1a6c3428cecf40d16a2365bcf56c424c92c2b6f0f9ad204b899e9e", size = 2127901, upload-time = "2025-10-10T15:03:27.548Z" },
     { url = "https://files.pythonhosted.org/packages/9c/5e/6a29fa884d9fb7ddadf6b69490a9d45fded3b38541713010dad16b77d015/sqlalchemy-2.0.44-py3-none-any.whl", hash = "sha256:19de7ca1246fbef9f9d1bff8f1ab25641569df226364a0e40457dc5457c54b05", size = 1928718, upload-time = "2025-10-10T15:29:45.32Z" },
+]
+
+[[package]]
+name = "tabula-py"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distro" },
+    { name = "numpy" },
+    { name = "pandas" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/31/2a14a5048f681c404ae0b32a00d141128dd3065965190fdcae3b33e2bcae/tabula_py-2.10.0.tar.gz", hash = "sha256:75968a83fe978e5d56ccf23f0f0255a459c256b7b52db7cabe5ac795bb3b12df", size = 12459408, upload-time = "2024-10-17T02:51:19.668Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/80/10bc6f303054d1a06eb8628f90e5997f4b1272956a477230f3fa95637c28/tabula_py-2.10.0-py3-none-any.whl", hash = "sha256:c7596c559fc813e313eb4fbc7aabe7e4290dbd04717c4cbe4aa4a2cafd00ab63", size = 12021009, upload-time = "2024-10-17T02:51:16.427Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add rule-based PDF extraction using Tabula as an alternative to LLM-based extraction.
rule-based extraction - reads from blob and outputs to blob. Tested on GHA and locally want to merge to main to see if it works w/ workflow triggers.# Auto genreated
## What's Added
- src/rule_based_extract.py - Tabula-based table extraction module
- scripts/run_rule_based_extraction_gha.py - GitHub Actions wrapper
- .github/workflows/rule-based-extract.yml - Automated workflow
- docs/rule-based-extraction.md - Documentation
- Added tabula-py dependency (requires Java)

## Features
- Fast extraction (~5-10 seconds per PDF)
- Free (no API costs)
- Deterministic results
- Blob storage integration
- Works alongside LLM extraction for comparison

## Testing
- Tested locally: extracted 84 records from OEW37-2025.pdf
- Tested in GHA: successfully saved to blob storage

Once merged, will auto-trigger after each PDF download.