### PR TITLE
Stop redundant downloads

### DIFF
--- a/.github/workflows/download-latest-who-pdf.yml
+++ b/.github/workflows/download-latest-who-pdf.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Download WHO PDF
         env:
           STAGE: dev
-          DSCI_AZ_BLOB_DEV_SAS: ${{ secrets.DSCI_AZ_BLOB_DEV_SAS_WRITE }}
+          DSCI_AZ_BLOB_DEV_SAS: ${{ secrets.DSCI_AZ_BLOB_DEV_SAS }}
           DSCI_AZ_BLOB_DEV_SAS_WRITE: ${{ secrets.DSCI_AZ_BLOB_DEV_SAS_WRITE }}
         run: |
           # Always upload to blob for scheduled runs; manual runs can opt-in

--- a/.github/workflows/download-latest-who-pdf.yml
+++ b/.github/workflows/download-latest-who-pdf.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Download WHO PDF
         env:
           STAGE: dev
+          DSCI_AZ_BLOB_DEV_SAS: ${{ secrets.DSCI_AZ_BLOB_DEV_SAS_WRITE }}
           DSCI_AZ_BLOB_DEV_SAS_WRITE: ${{ secrets.DSCI_AZ_BLOB_DEV_SAS_WRITE }}
         run: |
           # Always upload to blob for scheduled runs; manual runs can opt-in

--- a/.github/workflows/download-latest-who-pdf.yml
+++ b/.github/workflows/download-latest-who-pdf.yml
@@ -98,32 +98,55 @@ jobs:
       - name: Create job summary
         if: success()
         run: |
-          echo "## Download Successful! ✅" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
+          # Check if metadata.json exists and what status it contains
           if [ -f "downloads/metadata.json" ]; then
+            STATUS=$(uv run python -c "import json; print(json.load(open('downloads/metadata.json')).get('status', 'success'))" 2>/dev/null || echo "success")
             WEEK=$(uv run python -c "import json; print(json.load(open('downloads/metadata.json'))['week'])")
             YEAR=$(uv run python -c "import json; print(json.load(open('downloads/metadata.json'))['year'])")
             DATE_RANGE=$(uv run python -c "import json; print(json.load(open('downloads/metadata.json'))['date_range'])")
 
+            # Different headers based on status
+            if [ "$STATUS" = "already_exists" ]; then
+              echo "## Already Up-to-Date ✅" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "The latest bulletin already exists in blob storage. No download needed." >> $GITHUB_STEP_SUMMARY
+            else
+              echo "## Download Successful! ✅" >> $GITHUB_STEP_SUMMARY
+            fi
+
+            echo "" >> $GITHUB_STEP_SUMMARY
             echo "### Bulletin Details" >> $GITHUB_STEP_SUMMARY
             echo "- **Week**: $WEEK" >> $GITHUB_STEP_SUMMARY
             echo "- **Year**: $YEAR" >> $GITHUB_STEP_SUMMARY
             echo "- **Date Range**: $DATE_RANGE" >> $GITHUB_STEP_SUMMARY
-          fi
 
-          PDF=$(ls downloads/*.pdf 2>/dev/null | head -1)
-          if [ -f "$PDF" ]; then
-            SIZE=$(du -h "$PDF" | cut -f1)
-            NAME=$(basename "$PDF")
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "### Downloaded File" >> $GITHUB_STEP_SUMMARY
-            echo "- **Filename**: \`$NAME\`" >> $GITHUB_STEP_SUMMARY
-            echo "- **Size**: $SIZE" >> $GITHUB_STEP_SUMMARY
-          fi
+            # Show downloaded file info only if we actually downloaded
+            if [ "$STATUS" != "already_exists" ]; then
+              PDF=$(ls downloads/*.pdf 2>/dev/null | head -1)
+              if [ -f "$PDF" ]; then
+                SIZE=$(du -h "$PDF" | cut -f1)
+                NAME=$(basename "$PDF")
+                echo "" >> $GITHUB_STEP_SUMMARY
+                echo "### Downloaded File" >> $GITHUB_STEP_SUMMARY
+                echo "- **Filename**: \`$NAME\`" >> $GITHUB_STEP_SUMMARY
+                echo "- **Size**: $SIZE" >> $GITHUB_STEP_SUMMARY
+              fi
 
-          if [ "${{ inputs.upload_to_blob }}" = "true" ]; then
+              if [ "${{ inputs.upload_to_blob }}" = "true" ] || [ "${{ github.event_name }}" = "schedule" ]; then
+                echo "" >> $GITHUB_STEP_SUMMARY
+                echo "### Blob Storage" >> $GITHUB_STEP_SUMMARY
+                echo "☁️ PDF uploaded to Azure blob storage" >> $GITHUB_STEP_SUMMARY
+              fi
+            else
+              # Already exists - show blob path
+              BLOB_PATH=$(uv run python -c "import json; print(json.load(open('downloads/metadata.json'))['blob_path'])" 2>/dev/null || echo "N/A")
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "### Blob Storage" >> $GITHUB_STEP_SUMMARY
+              echo "📁 Existing blob: \`$BLOB_PATH\`" >> $GITHUB_STEP_SUMMARY
+            fi
+          else
+            # No metadata file - something went wrong or old behavior
+            echo "## Download Successful! ✅" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "### Blob Storage" >> $GITHUB_STEP_SUMMARY
-            echo "☁️ PDF uploaded to Azure blob storage" >> $GITHUB_STEP_SUMMARY
+            echo "⚠️ No metadata available" >> $GITHUB_STEP_SUMMARY
           fi

--- a/scripts/download_latest_who_pdf.py
+++ b/scripts/download_latest_who_pdf.py
@@ -803,15 +803,8 @@ def main():
                     with open(args.save_metadata, "w") as f:
                         json.dump(status_info, f, indent=2)
 
-                # Download existing log, append this run, and upload
-                # This ensures complete history of all runs
-                downloader.download_log_from_blob()
-                downloader.append_to_log(run_metadata)
-                log_path = downloader.output_dir / "download_log.jsonl"
-                if log_path.exists():
-                    downloader.upload_log_to_blob(log_path)
-
                 # Exit early - no PDF download needed
+                # Logging will be handled by finally block
                 return
 
         if not bulletin:

--- a/scripts/download_latest_who_pdf.py
+++ b/scripts/download_latest_who_pdf.py
@@ -753,8 +753,9 @@ def main():
         else:
             bulletin = downloader.get_latest_bulletin()
 
-        # For scheduled runs with upload: check if we already have this week in blob
-        if (run_context["trigger"] == "schedule" and bulletin and args.upload):
+        # For runs with upload enabled: check if we already have this week in blob
+        # This avoids re-downloading and re-uploading the same file
+        if bulletin and args.upload:
             expected_filename = bulletin.get_filename()
 
             if downloader.check_pdf_exists_in_blob(expected_filename):

--- a/scripts/download_latest_who_pdf.py
+++ b/scripts/download_latest_who_pdf.py
@@ -26,10 +26,14 @@ import json
 import logging
 import os
 import re
+
+# Import Config for centralized blob paths
+import sys
 import time
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from pathlib import Path
+from pathlib import Path as PathLib
 from typing import Dict, List, Optional
 
 import ocha_stratus as stratus
@@ -41,9 +45,6 @@ from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.chrome.options import Options
 from urllib3.util.retry import Retry
 
-# Import Config for centralized blob paths
-import sys
-from pathlib import Path as PathLib
 sys.path.insert(0, str(PathLib(__file__).parent.parent))
 from src.config import Config
 
@@ -313,7 +314,7 @@ class DownloadRunMetadata:
 
     # Run context
     run_date: str
-    status: str  # "success" or "failed"
+    status: str  # "success", "failed", or "already_exists"
     error_message: Optional[str]
     runner: str  # "github-actions" or "local"
     trigger: Optional[str]  # "schedule", "workflow_dispatch", etc.

--- a/scripts/download_latest_who_pdf.py
+++ b/scripts/download_latest_who_pdf.py
@@ -632,7 +632,8 @@ class LatestWHOPDFDownloader:
                 f.write(blob_data)
 
             # Count entries
-            num_entries = sum(1 for _ in open(local_log_path))
+            with open(local_log_path) as f:
+                num_entries = sum(1 for _ in f)
             logger.info(f"✓ Downloaded existing log with {num_entries} entries from blob")
             return local_log_path
         except Exception as e:
@@ -648,7 +649,8 @@ class LatestWHOPDFDownloader:
             return
 
         # Count entries before uploading
-        num_entries = sum(1 for _ in open(log_path))
+        with open(log_path) as f:
+            num_entries = sum(1 for _ in f)
 
         blob_path = f"{self.blob_proj_dir}/raw/monitoring/{log_path.name}"
         logger.info(f"Uploading log with {num_entries} entries to {blob_path}")


### PR DESCRIPTION
This pull request improves the reliability and clarity of the WHO PDF download workflow and its supporting script, especially for scheduled runs and cases where the latest bulletin already exists in blob storage. The changes enhance the job summary output, add more informative logging, and prevent redundant downloads and uploads.

**Workflow summary and reporting improvements:**

* The GitHub Actions workflow now checks if the latest bulletin already exists in blob storage and updates the job summary accordingly, showing a distinct "Already Up-to-Date" message and blob path when no download is needed. It also displays file details only if a new PDF was downloaded. [[1]](diffhunk://#diff-f5ecc4ea1674a604667bfb7a3dcc2ebc138fe7bfc44be8fa38b30c2a88093855L101-R125) [[2]](diffhunk://#diff-f5ecc4ea1674a604667bfb7a3dcc2ebc138fe7bfc44be8fa38b30c2a88093855L125-R153)
* Due to different ways of accessing the blob (stratus vs manual) different env vars are also needed.

**Script logic and logging enhancements:**

* The main script logic is refactored so that, for scheduled or upload-enabled runs, it first determines the latest bulletin and checks blob storage before attempting any download. If the bulletin already exists, it creates a metadata file with a new `already_exists` status and exits early, avoiding unnecessary scraping and uploading.
* Logging for download and upload of the monitoring log is improved: the number of entries is counted and reported in log messages, and warnings are used for missing logs to better distinguish normal and error conditions. [[1]](diffhunk://#diff-fa62d8e4af9f50c093715b8bb297b798489e928f95df9d45a5dc3c78a99d66f3L633-R641) [[2]](diffhunk://#diff-fa62d8e4af9f50c093715b8bb297b798489e928f95df9d45a5dc3c78a99d66f3R650-R654) [[3]](diffhunk://#diff-fa62d8e4af9f50c093715b8bb297b798489e928f95df9d45a5dc3c78a99d66f3L658-R665)