### PR TITLE
Add comparisons, master dataset, and pipeline fixes

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -1,0 +1,676 @@
+# GitHub Actions Workflows Documentation
+
+This document describes the automated workflows for the cholera PDF extraction and monitoring pipeline.
+
+## Table of Contents
+
+- [Workflow Overview](#workflow-overview)
+- [Workflow Details](#workflow-details)
+  - [1. Download Latest WHO PDF](#1-download-latest-who-pdf)
+  - [2. Extract Data from PDF (LLM)](#2-extract-data-from-pdf-llm)
+  - [3. Rule-Based Extraction](#3-rule-based-extraction)
+  - [4. Post-Process Extractions](#4-post-process-extractions)
+- [Comparison Generation](#comparison-generation)
+- [Manual Execution](#manual-execution)
+- [Monitoring & Troubleshooting](#monitoring--troubleshooting)
+
+---
+
+## Workflow Overview
+
+The extraction pipeline consists of four main workflows that run automatically or can be triggered manually:
+
+```mermaid
+graph TD
+    A[1. Download Latest WHO PDF<br/>Weekly Schedule<br/>- Downloads new bulletin<br/>- Uploads to blob storage]
+
+    A -->|Triggers| B[2. LLM Extraction<br/>GPT-4/GPT-5<br/>- Structured data<br/>- API-based]
+    A -->|Triggers| C[3. Rule-Based Extraction<br/>Tabula<br/>- Fast & free<br/>- Deterministic]
+
+    B -->|Outputs raw data| D[4a. Post-Process LLM<br/>- Standardization<br/>- Validation<br/>- Upload processed]
+    C -->|Outputs raw data| E[4b. Post-Process Rule-Based<br/>- Standardization<br/>- Validation<br/>- Upload processed]
+
+    D -->|Job 2| F[Comparison Generation<br/>- Discrepancy analysis<br/>- CFR consistency<br/>- Automatic when both sources available]
+    E -->|Job 2| F
+
+    F -->|Upload| G[Blob Storage<br/>processed/monitoring/comparisons/]
+
+    style A fill:#e1f5ff
+    style B fill:#fff4e1
+    style C fill:#fff4e1
+    style D fill:#e8f5e9
+    style E fill:#e8f5e9
+    style F fill:#f3e5f5
+    style G fill:#fce4ec
+```
+
+---
+
+## Workflow Details
+
+### 1. Download Latest WHO PDF
+
+**File:** `.github/workflows/download-latest-who-pdf.yml`
+
+**Purpose:** Downloads the latest WHO Weekly Epidemiological Record bulletin.
+
+**Trigger:**
+- **Schedule:** Every Monday at 10:00 AM UTC
+- **Manual:** `workflow_dispatch`
+
+**Inputs:**
+- `week_number` (optional): Specific week to download
+- `year` (optional): Year (required if week specified)
+
+**Outputs:**
+- PDF uploaded to: `ds-cholera-pdf-scraper/raw/monitoring/pdfs/`
+- Download log: `ds-cholera-pdf-scraper/raw/monitoring/download_log.jsonl`
+
+**Environment Variables:**
+- `DSCI_AZ_BLOB_DEV_SAS_WRITE`: Azure blob storage SAS token
+
+**Example Manual Run:**
+```bash
+# Download latest bulletin
+gh workflow run download-latest-who-pdf.yml
+
+# Download specific week
+gh workflow run download-latest-who-pdf.yml -f week_number=42 -f year=2025
+```
+
+---
+
+### 2. Extract Data from PDF (LLM)
+
+**File:** `.github/workflows/extract-from-pdf.yml`
+
+**Purpose:** Extracts cholera surveillance data using LLM (GPT-4o or GPT-5).
+
+**Trigger:**
+- **Automatic:** After successful PDF download
+- **Manual:** `workflow_dispatch`
+
+**Inputs:**
+- `week_number` (optional): Week to extract
+- `year` (optional): Year
+- `model` (optional): LLM model (default: `gpt-5`)
+
+**Process:**
+1. Downloads PDF from blob storage
+2. Extracts data using LLM
+3. Uploads raw extraction to: `ds-cholera-pdf-scraper/raw/monitoring/llm_extractions/`
+4. Triggers post-processing workflow
+
+**Environment Variables:**
+- `DSCI_AZ_OPENAI_API_KEY_WHO_CHOLERA`: OpenAI API key
+- `DSCI_AZ_BLOB_DEV_SAS_WRITE`: Blob storage token
+- `STAGE`: Deployment stage (dev/prod)
+
+**Example Manual Run:**
+```bash
+# Extract latest with GPT-5
+gh workflow run extract-from-pdf.yml
+
+# Extract specific week with GPT-4o
+gh workflow run extract-from-pdf.yml -f week_number=42 -f year=2025 -f model=gpt-4o
+```
+
+---
+
+### 3. Rule-Based Extraction
+
+**File:** `.github/workflows/rule-based-extract.yml`
+
+**Purpose:** Extracts data using rule-based table detection (Tabula).
+
+**Trigger:**
+- **Automatic:** After successful PDF download
+- **Manual:** `workflow_dispatch`
+
+**Inputs:**
+- `week_number` (optional): Week to extract
+- `year` (optional): Year
+
+**Process:**
+1. Downloads PDF from blob storage
+2. Extracts tables using Tabula (lattice detection)
+3. Uploads raw extraction to: `ds-cholera-pdf-scraper/raw/monitoring/rule_based_extractions/`
+4. Triggers post-processing workflow
+
+**Advantages:**
+- ⚡ Fast (no API calls)
+- 💰 Free (no LLM costs)
+- 🎯 Deterministic (same input = same output)
+
+**Disadvantages:**
+- Sensitive to PDF format changes
+- May miss complex table structures
+
+**Environment Variables:**
+- `DSCI_AZ_BLOB_DEV_SAS_WRITE`: Blob storage token
+- `STAGE`: Deployment stage
+
+**Example Manual Run:**
+```bash
+# Extract latest
+gh workflow run rule-based-extract.yml
+
+# Extract specific week
+gh workflow run rule-based-extract.yml -f week_number=42 -f year=2025
+```
+
+---
+
+### 4. Post-Process Extractions
+
+**File:** `.github/workflows/post-process-extractions.yml`
+
+**Purpose:** Applies standardization and cleaning to raw extractions.
+
+**Trigger:**
+- **Automatic:** Called by extraction workflows
+- **Manual:** `workflow_dispatch`
+
+**Inputs:**
+- `source` (required): `llm`, `rule-based`, or `both`
+- `week_number` (optional): Week to process
+- `year` (optional): Year
+- `limit` (optional): Limit to N most recent files
+- `correct_gap_fill` (optional): Apply experimental gap-filling corrections
+
+**Jobs:**
+
+#### Job 1: post-process
+Processes raw extractions and uploads cleaned data.
+
+**Process:**
+1. Downloads raw CSV from: `raw/monitoring/{llm,rule_based}_extractions/`
+2. Applies post-processing pipeline:
+   - Clean numerical fields (remove commas)
+   - Standardize CFR format (remove %)
+   - Standardize event names
+   - Standardize country names
+   - Standardize column names
+   - Harmonize missing values
+   - (Optional) Apply gap-filling corrections
+3. Validates processed data
+4. Uploads to: `processed/monitoring/{llm,rule_based}_extractions/`
+
+**Output:**
+- Processed CSVs with `_processed.csv` suffix
+- Example: `OEW42-2025_gpt-5_123_processed.csv`
+
+#### Job 2: generate-comparisons
+Automatically generates comparison reports when both LLM and rule-based data exist.
+
+**Process:**
+1. Checks if week/year are specified
+2. Attempts to load BOTH LLM and rule-based processed files
+3. If both exist:
+   - Performs discrepancy analysis
+   - Categorizes differences (comma issues, zero vs non-zero, magnitude)
+   - Checks CFR consistency
+   - Identifies unique records (only in one source)
+   - Uploads comparison files to blob storage
+4. If one missing:
+   - Fails gracefully with informative message
+   - Workflow still succeeds (green checkmark)
+
+**Comparison Outputs:**
+- `OEW{week}-{year}_comparison_summary.csv` - Summary statistics
+- `OEW{week}-{year}_discrepancies.csv` - Detailed discrepancies
+- `OEW{week}-{year}_cfr_comparison.csv` - CFR consistency analysis
+- `OEW{week}-{year}_unique_records.csv` - Records unique to each source
+
+**Location:** `ds-cholera-pdf-scraper/processed/monitoring/comparisons/`
+
+**Error Handling:**
+- Uses `continue-on-error: true` to never block pipeline
+- Graceful failure if counterpart data doesn't exist
+- Clear error messages in logs
+
+**Environment Variables:**
+- `DSCI_AZ_BLOB_DEV_SAS_WRITE`: Blob storage token
+- `STAGE`: Deployment stage
+
+**Example Manual Run:**
+```bash
+# Process all LLM extractions
+gh workflow run post-process-extractions.yml -f source=llm
+
+# Process specific week (both sources)
+gh workflow run post-process-extractions.yml -f source=both -f week_number=42 -f year=2025
+
+# Process with gap-filling corrections
+gh workflow run post-process-extractions.yml -f source=llm -f week_number=42 -f year=2025 -f correct_gap_fill=true
+```
+
+---
+
+## Comparison Generation
+
+### How It Works
+
+The comparison system automatically generates quality reports when both LLM and rule-based extractions are available for the same week.
+
+### Automatic Triggers
+
+Comparisons are generated automatically when:
+1. Post-processing completes successfully
+2. Week and year are specified in workflow inputs
+3. BOTH LLM and rule-based processed files exist for that week/year
+
+### Decision Logic
+
+```mermaid
+flowchart TD
+    A[Post-processing completes] --> B{Week/year<br/>specified?}
+    B -->|No| C[Skip comparison<br/>No error]
+    B -->|Yes| D{LLM processed<br/>file exists?}
+    D -->|No| E[Fail gracefully<br/>Workflow succeeds ✅<br/>Log helpful message]
+    D -->|Yes| F{Rule-based processed<br/>file exists?}
+    F -->|No| E
+    F -->|Yes| G[Generate comparison ✅]
+    G --> H[Upload to blob storage]
+    H --> I[Workflow succeeds ✅]
+
+    style A fill:#e1f5ff
+    style B fill:#fff4e1
+    style C fill:#f0f0f0
+    style D fill:#fff4e1
+    style E fill:#fff9c4
+    style F fill:#fff4e1
+    style G fill:#c8e6c9
+    style H fill:#c8e6c9
+    style I fill:#c8e6c9
+```
+
+### File Selection
+
+When multiple processed files exist for the same week/year:
+- Sorts by `run_id` (timestamp) descending
+- Selects most recent file
+- Example: If you have:
+  - `OEW42-2025_gpt-5_100.csv`
+  - `OEW42-2025_gpt-5_200.csv` ← Selected (most recent)
+  - `OEW42-2025_gpt-5_300.csv` ← Selected (most recent)
+
+### Discrepancy Categories
+
+Discrepancies are automatically categorized:
+- **Zero vs Non-Zero**: One source has 0, the other has a value
+- **Comma/Thousands Issue**: Values differ by 10x, 100x, or 1000x
+- **Large Difference (>100)**: Absolute difference exceeds 100
+- **Medium Difference (21-100)**: Absolute difference between 21-100
+- **Small Difference (≤20)**: Absolute difference 20 or less
+
+### CFR Consistency Check
+
+For each discrepancy with CFR data:
+- Calculates: `CFR_error = |calculated_CFR - stated_CFR|`
+- Calculated CFR: `(Deaths / TotalCases) × 100`
+- Identifies which source (LLM or rule-based) has better CFR consistency
+
+### Manual Comparison Generation
+
+If workflows get out of sync, generate comparisons manually:
+
+```bash
+# Using standalone CLI (local)
+python -m src.monitoring.comparisons --week 42 --year 2025 --stage dev --output ./results
+
+# Using standalone CLI (upload to blob)
+python -m src.monitoring.comparisons --week 42 --year 2025 --stage dev
+
+# Compare specific files
+python -m src.monitoring.comparisons \
+  --llm-file OEW42-2025_gpt-5_processed.csv \
+  --rule-based-file OEW42-2025_rule-based_processed.csv \
+  --output ./results
+
+# Compare date range
+python -m src.monitoring.comparisons --start-date 2025-01-01 --end-date 2025-03-31 --stage dev
+```
+
+---
+
+## Manual Execution
+
+### Using GitHub CLI
+
+All workflows support manual execution via GitHub CLI:
+
+```bash
+# Check available workflows
+gh workflow list
+
+# View recent runs
+gh run list --limit 10
+
+# Trigger a workflow
+gh workflow run <workflow-name.yml> -f input1=value1 -f input2=value2
+
+# Run on specific branch
+gh workflow run <workflow-name.yml> --ref feature-branch
+
+# View run status
+gh run view <run-id>
+
+# View run logs
+gh run view <run-id> --log
+
+# Watch run in progress
+gh run watch <run-id>
+```
+
+### Using GitHub UI
+
+1. Navigate to **Actions** tab
+2. Select workflow from left sidebar
+3. Click **Run workflow** button
+4. Fill in inputs (if any)
+5. Click **Run workflow**
+
+---
+
+## Monitoring & Troubleshooting
+
+### Checking Workflow Status
+
+```bash
+# List recent runs for specific workflow
+gh run list --workflow=post-process-extractions.yml --limit 10
+
+# View specific run
+gh run view 19867595169
+
+# Check logs for errors
+gh run view 19867595169 --log | grep -i error
+
+# View specific job
+gh run view --job=56934544642
+```
+
+### Common Issues
+
+#### 1. Comparison Job Fails (Expected)
+
+**Symptom:**
+```
+⚠️  Comparison generation failed
+This is expected if only one extraction type has been run.
+```
+
+**Cause:** Only one source (LLM or rule-based) has processed data for that week.
+
+**Solution:** This is EXPECTED behavior. Run the missing extraction:
+```bash
+# If LLM is missing
+gh workflow run extract-from-pdf.yml -f week_number=42 -f year=2025
+
+# If rule-based is missing
+gh workflow run rule-based-extract.yml -f week_number=42 -f year=2025
+```
+
+#### 2. Comparison Job Succeeds But No Files Generated
+
+**Symptom:** Workflow shows green checkmark but no comparison files in blob storage.
+
+**Cause:** Comparison detected no discrepancies or only one unique record type.
+
+**Solution:** Check the logs:
+```bash
+gh run view <run-id> --log | grep "Value discrepancies"
+```
+
+If it shows `Value discrepancies: 0`, this is expected (no differences found).
+
+#### 3. Blob Upload Failures
+
+**Symptom:**
+```
+❌ Failed to upload to blob storage
+```
+
+**Cause:**
+- SAS token expired
+- Network issues
+- Blob storage service unavailable
+
+**Solution:**
+1. Check SAS token in repository secrets
+2. Verify blob storage is accessible
+3. Re-run workflow after checking GitHub Actions status
+
+#### 4. Post-Processing Fails
+
+**Symptom:**
+```
+## Post-Processing Failed ❌
+```
+
+**Cause:**
+- Invalid CSV format
+- Missing required columns
+- Data validation errors
+
+**Solution:**
+1. Check logs for specific error
+2. Inspect raw CSV file in blob storage
+3. Verify extraction workflow completed successfully
+
+### Viewing Comparison Results
+
+**In blob storage:**
+1. Navigate to Azure Storage Explorer
+2. Open container: `projects`
+3. Path: `ds-cholera-pdf-scraper/processed/monitoring/comparisons/`
+4. Download CSV files
+
+**Using Python:**
+```python
+from src.monitoring.comparisons import BlobExtractionLoader
+
+loader = BlobExtractionLoader(stage='dev')
+
+# List available comparisons
+comparisons = loader.list_available_extractions('comparisons')
+print(comparisons)
+
+# Load specific comparison
+import pandas as pd
+import ocha_stratus as stratus
+
+df = stratus.load_csv_from_blob(
+    blob_name='ds-cholera-pdf-scraper/processed/monitoring/comparisons/OEW42-2025_discrepancies.csv',
+    stage='dev',
+    container_name='projects'
+)
+print(df)
+```
+
+### Monitoring Best Practices
+
+1. **Set up notifications:**
+   - Enable GitHub Actions email notifications
+   - Use workflow status badges in README
+
+2. **Regular checks:**
+   - Review workflow runs weekly
+   - Check for failed comparison jobs
+   - Monitor blob storage usage
+
+3. **Data quality:**
+   - Review discrepancy reports regularly
+   - Investigate high-discrepancy weeks
+   - Update extraction rules based on findings
+
+4. **Cost monitoring:**
+   - LLM extraction: ~$0.01-0.05 per bulletin
+   - Rule-based: Free (compute only)
+   - Storage: Minimal (~50MB per week)
+
+---
+
+## Workflow Configuration
+
+### Secrets Required
+
+Configure in repository settings → Secrets and variables → Actions:
+
+- `DSCI_AZ_BLOB_DEV_SAS_WRITE`: Azure blob storage SAS token (write access)
+- `DSCI_AZ_OPENAI_API_KEY_WHO_CHOLERA`: OpenAI API key
+
+### Environment Variables
+
+Set in workflow YAML files:
+
+- `STAGE`: Deployment stage (`dev` or `prod`)
+- `PYTHONUNBUFFERED`: Force unbuffered output (set to `1`)
+- `LOG_BACKEND`: Logging backend (`duckdb`, `sqlite`, or `jsonl`)
+
+### Scheduled Runs
+
+Current schedule:
+- **Download PDF**: Every Monday at 10:00 AM UTC
+  - Cron: `0 10 * * 1`
+
+To modify schedule, edit the workflow YAML:
+```yaml
+on:
+  schedule:
+    - cron: '0 10 * * 1'  # Every Monday at 10:00 UTC
+```
+
+---
+
+## Development & Testing
+
+### Testing Workflows Locally
+
+**Install dependencies:**
+```bash
+uv sync --frozen
+```
+
+**Test post-processing:**
+```bash
+python scripts/process_raw_extractions.py --source both --week 42 --year 2025 --limit 1
+```
+
+**Test comparison generation:**
+```bash
+python -m src.monitoring.comparisons --week 42 --year 2025 --stage dev --output ./test_output
+```
+
+### Testing in GitHub Actions
+
+**Using feature branches:**
+```bash
+# Create feature branch
+git checkout -b test/workflow-changes
+
+# Push changes
+git push origin test/workflow-changes
+
+# Run workflow on feature branch
+gh workflow run post-process-extractions.yml --ref test/workflow-changes
+```
+
+### Rollback Procedure
+
+If a workflow change causes issues:
+
+```bash
+# Revert the commit
+git revert <commit-hash>
+git push origin main
+
+# Or revert to specific commit
+git reset --hard <good-commit-hash>
+git push origin main --force  # Use with caution
+```
+
+Workflows will automatically use the latest version from the branch they run on.
+
+---
+
+## Architecture Decisions
+
+### Why Separate Post-Processing Workflow?
+
+**Reusability:** Both LLM and rule-based extractions use the same post-processing logic.
+
+**Flexibility:** Can re-process historical data without re-running extractions.
+
+**Testing:** Can test post-processing changes independently.
+
+### Why Comparison in Post-Processing Job?
+
+**Automatic:** Runs whenever both sources are available without manual coordination.
+
+**Non-blocking:** Uses `continue-on-error: true` to never fail the pipeline.
+
+**Efficient:** Reuses already-processed data; no redundant downloads.
+
+### Why Graceful Failure?
+
+**Flexibility:** Workflows can run independently (LLM-only or rule-based-only).
+
+**Reliability:** Critical post-processing always completes even if comparison fails.
+
+**Transparency:** Clear logs explain why comparison didn't run.
+
+---
+
+## Future Enhancements
+
+### Planned Features
+
+1. **Automated Quality Gates**
+   - Fail workflow if discrepancy rate > threshold
+   - Require manual review for high-discrepancy weeks
+
+2. **Comparison Dashboard**
+   - HTML dashboard with trend charts
+   - Interactive discrepancy viewer
+   - Upload to blob storage alongside CSVs
+
+3. **Notification System**
+   - Slack/email alerts for high discrepancies
+   - Summary reports for weekly runs
+   - Alert on comparison generation failures
+
+4. **Historical Batch Processing**
+   - Workflow to generate comparisons for all historical data
+   - Bulk comparison report generation
+   - Trend analysis across multiple weeks
+
+### Contributing
+
+When modifying workflows:
+
+1. **Test locally first** using the scripts directly
+2. **Create feature branch** for workflow changes
+3. **Test in GitHub Actions** on feature branch
+4. **Document changes** in this file
+5. **Update comparison logic** in `src/monitoring/comparisons.py` if needed
+
+---
+
+## Resources
+
+- [GitHub Actions Documentation](https://docs.github.com/en/actions)
+- [GitHub CLI Documentation](https://cli.github.com/manual/)
+- [Azure Blob Storage Python SDK](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-python)
+- [Comparison Module Source](../src/monitoring/comparisons.py)
+- [Post-Processing Source](../src/post_processing.py)
+
+---
+
+## Contact
+
+For workflow issues or questions:
+- File an issue in the repository
+- Check GitHub Actions logs for detailed error messages
+- Review this documentation for troubleshooting steps

--- a/.github/workflows/extract-from-pdf.yml
+++ b/.github/workflows/extract-from-pdf.yml
@@ -52,6 +52,7 @@ jobs:
           uv sync --frozen
 
       - name: Run extraction
+        id: run_extraction
         env:
           DSCI_AZ_OPENAI_API_KEY_WHO_CHOLERA: ${{ secrets.DSCI_AZ_OPENAI_API_KEY_WHO_CHOLERA }}
           DSCI_AZ_BLOB_DEV_SAS: ${{ secrets.DSCI_AZ_BLOB_DEV_SAS_WRITE }}
@@ -80,22 +81,36 @@ jobs:
             ARGS="$ARGS --model ${{ inputs.model }}"
           fi
 
-          # Run extraction
-          uv run python scripts/run_llm_extraction_gha.py $ARGS
+          # Run extraction and capture output
+          OUTPUT=$(uv run python scripts/run_llm_extraction_gha.py $ARGS 2>&1)
+          echo "$OUTPUT"
+
+          # Extract week/year from output
+          WEEK=$(echo "$OUTPUT" | grep "EXTRACTION_WEEK=" | cut -d'=' -f2 | tr -d '[:space:]')
+          YEAR=$(echo "$OUTPUT" | grep "EXTRACTION_YEAR=" | cut -d'=' -f2 | tr -d '[:space:]')
+
+          # Save to GitHub output
+          if [ -n "$WEEK" ] && [ -n "$YEAR" ]; then
+            echo "week=$WEEK" >> $GITHUB_OUTPUT
+            echo "year=$YEAR" >> $GITHUB_OUTPUT
+          fi
 
       - name: Extract week/year info for post-processing
         id: extract_info
         run: |
-          # Determine week/year that was extracted
-          if [ -n "${{ inputs.week_number }}" ] && [ -n "${{ inputs.year }}" ]; then
+          # Use extracted week/year from the actual PDF processed
+          if [ -n "${{ steps.run_extraction.outputs.week }}" ] && [ -n "${{ steps.run_extraction.outputs.year }}" ]; then
+            echo "week_number=${{ steps.run_extraction.outputs.week }}" >> $GITHUB_OUTPUT
+            echo "year=${{ steps.run_extraction.outputs.year }}" >> $GITHUB_OUTPUT
+            echo "ℹ️  Using week/year from extracted PDF: Week ${{ steps.run_extraction.outputs.week }}, Year ${{ steps.run_extraction.outputs.year }}"
+          elif [ -n "${{ inputs.week_number }}" ] && [ -n "${{ inputs.year }}" ]; then
+            # Fallback to inputs if extraction didn't output week/year
             echo "week_number=${{ inputs.week_number }}" >> $GITHUB_OUTPUT
             echo "year=${{ inputs.year }}" >> $GITHUB_OUTPUT
+            echo "ℹ️  Using week/year from inputs: Week ${{ inputs.week_number }}, Year ${{ inputs.year }}"
           else
-            # For "latest", we need to determine the current week
-            WEEK=$(date +%V)
-            YEAR=$(date +%Y)
-            echo "week_number=$WEEK" >> $GITHUB_OUTPUT
-            echo "year=$YEAR" >> $GITHUB_OUTPUT
+            echo "⚠️  WARNING: Could not determine week/year from extraction output"
+            echo "This may cause issues with post-processing and comparisons"
           fi
 
       - name: Create job summary

--- a/.github/workflows/post-process-extractions.yml
+++ b/.github/workflows/post-process-extractions.yml
@@ -244,13 +244,14 @@ jobs:
           echo "- 📊 Blob storage: \`ds-cholera-pdf-scraper/processed/monitoring/comparisons/\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Files Generated" >> $GITHUB_STEP_SUMMARY
-          echo "- \`OEW${{ inputs.week_number }}-${{ inputs.year }}_comparison_summary.csv\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`OEW${{ inputs.week_number }}-${{ inputs.year }}_discrepancies.csv\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`OEW${{ inputs.week_number }}-${{ inputs.year }}_cfr_comparison.csv\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`OEW${{ inputs.week_number }}-${{ inputs.year }}_unique_records.csv\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`OEW${{ inputs.week_number }}-${{ inputs.year }}_comparison_summary.csv\` - High-level statistics" >> $GITHUB_STEP_SUMMARY
+          echo "- \`OEW${{ inputs.week_number }}-${{ inputs.year }}_discrepancies.csv\` - Detailed field-by-field differences" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### What This Compares" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ Value discrepancies between LLM and rule-based extractions" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ CFR consistency checks" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ Records unique to each source" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ Categorized discrepancies (comma issues, zero vs non-zero, etc.)" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Categorized discrepancies (comma issues, zero vs non-zero, magnitude differences)" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Agreement metrics and summary statistics" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Master Dataset" >> $GITHUB_STEP_SUMMARY
+          echo "- 📋 Production-ready master: \`ds-cholera-pdf-scraper/processed/monitoring/master_extractions/OEW${{ inputs.week_number }}-${{ inputs.year }}_master.csv\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Analysts can review discrepancies and create \`OEW${{ inputs.week_number }}-${{ inputs.year }}_master_edit.csv\` if corrections needed" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/post-process-extractions.yml
+++ b/.github/workflows/post-process-extractions.yml
@@ -154,3 +154,94 @@ jobs:
           echo "## Post-Processing Failed ❌" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Check the logs above for error details." >> $GITHUB_STEP_SUMMARY
+
+  generate-comparisons:
+    needs: post-process
+    if: success()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: |
+          # Install full project dependencies
+          uv sync --frozen
+
+      - name: Try to generate comparison
+        env:
+          DSCI_AZ_BLOB_DEV_SAS: ${{ secrets.DSCI_AZ_BLOB_DEV_SAS_WRITE }}
+          DSCI_AZ_BLOB_DEV_SAS_WRITE: ${{ secrets.DSCI_AZ_BLOB_DEV_SAS_WRITE }}
+          STAGE: dev
+          PYTHONUNBUFFERED: 1
+        continue-on-error: true
+        run: |
+          # Only run if week/year are specified
+          if [ -n "${{ inputs.week_number }}" ] && [ -n "${{ inputs.year }}" ]; then
+            echo "============================================================"
+            echo "Attempting to generate comparison for Week ${{ inputs.week_number }}, Year ${{ inputs.year }}..."
+            echo "============================================================"
+            echo ""
+
+            # Build arguments
+            ARGS="--week ${{ inputs.week_number }} --year ${{ inputs.year }}"
+
+            # Add gap-fill flag if enabled
+            if [ "${{ inputs.correct_gap_fill }}" == "true" ]; then
+              ARGS="$ARGS --correct-gap-fill"
+            fi
+
+            # Run comparison generation (standalone mode)
+            # This will fail gracefully if counterpart data doesn't exist
+            uv run python -m src.monitoring.comparisons $ARGS || {
+              echo ""
+              echo "============================================================"
+              echo "⚠️  Comparison generation failed"
+              echo "============================================================"
+              echo "This is expected if only one extraction type has been run."
+              echo "Comparison requires BOTH LLM and rule-based processed data."
+              echo ""
+              echo "To generate comparison manually:"
+              echo "  python -m src.monitoring.comparisons --week ${{ inputs.week_number }} --year ${{ inputs.year }}"
+              echo "============================================================"
+              exit 0  # Don't fail the workflow
+            }
+          else
+            echo "ℹ️  Skipping comparison generation (no week/year specified)"
+            echo "Comparisons are only generated for specific week/year processing."
+          fi
+
+      - name: Create comparison summary
+        if: success()
+        run: |
+          echo "## Comparison Report Generated ✅" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Details" >> $GITHUB_STEP_SUMMARY
+          echo "- **Week/Year**: ${{ inputs.week_number }}/${{ inputs.year }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Stage**: dev" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Output Location" >> $GITHUB_STEP_SUMMARY
+          echo "- 📊 Blob storage: \`ds-cholera-pdf-scraper/processed/monitoring/comparisons/\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Files Generated" >> $GITHUB_STEP_SUMMARY
+          echo "- \`OEW${{ inputs.week_number }}-${{ inputs.year }}_comparison_summary.csv\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`OEW${{ inputs.week_number }}-${{ inputs.year }}_discrepancies.csv\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`OEW${{ inputs.week_number }}-${{ inputs.year }}_cfr_comparison.csv\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`OEW${{ inputs.week_number }}-${{ inputs.year }}_unique_records.csv\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### What This Compares" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Value discrepancies between LLM and rule-based extractions" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ CFR consistency checks" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Records unique to each source" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Categorized discrepancies (comma issues, zero vs non-zero, etc.)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/post-process-extractions.yml
+++ b/.github/workflows/post-process-extractions.yml
@@ -133,8 +133,17 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Outputs" >> $GITHUB_STEP_SUMMARY
           echo "- 📄 Processed CSVs uploaded to:" >> $GITHUB_STEP_SUMMARY
-          echo "  - LLM: \`ds-cholera-pdf-scraper/processed/monitoring/llm_extractions/\`" >> $GITHUB_STEP_SUMMARY
-          echo "  - Rule-based: \`ds-cholera-pdf-scraper/processed/monitoring/rule_based_extractions/\`" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ inputs.source }}" == "llm" ] || [ "${{ inputs.source }}" == "both" ] || [ -z "${{ inputs.source }}" ]; then
+            echo "  - LLM: \`ds-cholera-pdf-scraper/processed/monitoring/llm_extractions/\`" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ "${{ inputs.source }}" == "rule-based" ] || [ "${{ inputs.source }}" == "both" ] || [ -z "${{ inputs.source }}" ]; then
+            echo "  - Rule-based: \`ds-cholera-pdf-scraper/processed/monitoring/rule_based_extractions/\`" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ "${{ inputs.source }}" == "llm" ] || [ "${{ inputs.source }}" == "both" ] || [ -z "${{ inputs.source }}" ]; then
+            if [ -n "${{ inputs.week_number }}" ] && [ -n "${{ inputs.year }}" ]; then
+              echo "- 📋 **Master dataset created**: \`ds-cholera-pdf-scraper/processed/monitoring/master_extractions/OEW${{ inputs.week_number }}-${{ inputs.year }}_master.csv\`" >> $GITHUB_STEP_SUMMARY
+            fi
+          fi
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Post-Processing Pipeline" >> $GITHUB_STEP_SUMMARY
           echo "Applies the following transformations:" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/rule-based-extract.yml
+++ b/.github/workflows/rule-based-extract.yml
@@ -53,6 +53,7 @@ jobs:
           uv sync --frozen
 
       - name: Run rule-based extraction
+        id: run_extraction
         env:
           DSCI_AZ_BLOB_DEV_SAS: ${{ secrets.DSCI_AZ_BLOB_DEV_SAS_WRITE }}
           DSCI_AZ_BLOB_DEV_SAS_WRITE: ${{ secrets.DSCI_AZ_BLOB_DEV_SAS_WRITE }}
@@ -74,22 +75,36 @@ jobs:
             ARGS="$ARGS --year ${{ inputs.year }}"
           fi
 
-          # Run extraction
-          uv run python scripts/run_rule_based_extraction_gha.py $ARGS
+          # Run extraction and capture output
+          OUTPUT=$(uv run python scripts/run_rule_based_extraction_gha.py $ARGS 2>&1)
+          echo "$OUTPUT"
+
+          # Extract week/year from output
+          WEEK=$(echo "$OUTPUT" | grep "EXTRACTION_WEEK=" | cut -d'=' -f2 | tr -d '[:space:]')
+          YEAR=$(echo "$OUTPUT" | grep "EXTRACTION_YEAR=" | cut -d'=' -f2 | tr -d '[:space:]')
+
+          # Save to GitHub output
+          if [ -n "$WEEK" ] && [ -n "$YEAR" ]; then
+            echo "week=$WEEK" >> $GITHUB_OUTPUT
+            echo "year=$YEAR" >> $GITHUB_OUTPUT
+          fi
 
       - name: Extract week/year info for post-processing
         id: extract_info
         run: |
-          # Determine week/year that was extracted
-          if [ -n "${{ inputs.week_number }}" ] && [ -n "${{ inputs.year }}" ]; then
+          # Use extracted week/year from the actual PDF processed
+          if [ -n "${{ steps.run_extraction.outputs.week }}" ] && [ -n "${{ steps.run_extraction.outputs.year }}" ]; then
+            echo "week_number=${{ steps.run_extraction.outputs.week }}" >> $GITHUB_OUTPUT
+            echo "year=${{ steps.run_extraction.outputs.year }}" >> $GITHUB_OUTPUT
+            echo "ℹ️  Using week/year from extracted PDF: Week ${{ steps.run_extraction.outputs.week }}, Year ${{ steps.run_extraction.outputs.year }}"
+          elif [ -n "${{ inputs.week_number }}" ] && [ -n "${{ inputs.year }}" ]; then
+            # Fallback to inputs if extraction didn't output week/year
             echo "week_number=${{ inputs.week_number }}" >> $GITHUB_OUTPUT
             echo "year=${{ inputs.year }}" >> $GITHUB_OUTPUT
+            echo "ℹ️  Using week/year from inputs: Week ${{ inputs.week_number }}, Year ${{ inputs.year }}"
           else
-            # For "latest", we need to determine the current week
-            WEEK=$(date +%V)
-            YEAR=$(date +%Y)
-            echo "week_number=$WEEK" >> $GITHUB_OUTPUT
-            echo "year=$YEAR" >> $GITHUB_OUTPUT
+            echo "⚠️  WARNING: Could not determine week/year from extraction output"
+            echo "This may cause issues with post-processing and comparisons"
           fi
 
       - name: Create job summary

--- a/docs/architecture_for_analysts.md
+++ b/docs/architecture_for_analysts.md
@@ -28,7 +28,7 @@ graph TB
 
     subgraph "2. Parallel Extractions"
         B[Rule-Based Extraction<br/>Tabula table detection<br/>✅ Fast, free, deterministic<br/>⚠️ Can miss complex tables]
-        C[LLM Extraction<br/>GPT-4/GPT-5<br/>✅ Better accuracy, handles complexity<br/>⚠️ Occasional mistakes, costs money]
+        C[LLM Extraction<br/>GPT-5<br/>✅ Better accuracy, handles complexity<br/>⚠️ Occasional mistakes, costs money]
     end
 
     subgraph "3. Post-Processing"
@@ -110,53 +110,39 @@ graph TB
 
 The Azure blob storage is organized with a clear separation between raw and processed data:
 
-```mermaid
-graph TD
-    A[ds-cholera-pdf-scraper/]
-
-    A --> B[raw/]
-    A --> C[processed/]
-
-    B --> B1[monitoring/]
-    B1 --> B1a[pdfs/<br/>Original WHO bulletins<br/>OEWxx-YYYY.pdf]
-    B1 --> B1b[llm_extractions/<br/>Raw LLM output<br/>OEWxx-YYYY_gpt-5_runid.csv]
-    B1 --> B1c[rule_based_extractions/<br/>Raw rule-based output<br/>OEWxx-YYYY_rule-based_runid.csv]
-
-    C --> C1[monitoring/]
-    C --> C2[logs/]
-
-    C1 --> C1a[llm_extractions/<br/>Cleaned LLM data<br/>OEWxx-YYYY_gpt-5_runid_processed.csv]
-    C1 --> C1b[rule_based_extractions/<br/>Cleaned rule-based data<br/>OEWxx-YYYY_rule-based_runid_processed.csv]
-    C1 --> C1c[comparisons/<br/>Discrepancy analysis<br/>OEWxx-YYYY_comparison_summary.csv<br/>OEWxx-YYYY_discrepancies.csv]
-    C1 --> C1d[master_extractions/<br/>Production-ready data<br/>OEWxx-YYYY_master.csv<br/>OEWxx-YYYY_master_edit.csv]
-
-    C2 --> C2a[prompt_logs/<br/>LLM API logs]
-    C2 --> C2b[tabular_preprocessing_logs/<br/>Rule-based extraction logs]
-
-    style A fill:#e1f5ff
-    style B fill:#fff4e1
-    style C fill:#e8f5e9
-    style B1a fill:#ffccbc
-    style B1b fill:#ffccbc
-    style B1c fill:#ffccbc
-    style C1a fill:#c8e6c9
-    style C1b fill:#c8e6c9
-    style C1c fill:#b2dfdb
-    style C1d fill:#aed581
+```
+ds-cholera-pdf-scraper/
+├── raw/
+│   └── monitoring/
+│       ├── pdfs/                          # Original WHO bulletins
+│       ├── llm_extractions/               # Unprocessed LLM output
+│       └── rule_based_extractions/        # Unprocessed rule-based output
+│
+└── processed/
+    ├── monitoring/
+    │   ├── llm_extractions/               # Cleaned, standardized LLM data
+    │   ├── rule_based_extractions/        # Cleaned, standardized rule-based data
+    │   ├── comparisons/                   # Discrepancy analysis (2 CSV files)
+    │   └── master_extractions/            # Production-ready master dataset
+    │
+    └── logs/
+        ├── prompt_logs/                   # LLM API call logs
+        └── tabular_preprocessing_logs/    # Rule-based extraction logs
 ```
 
-### Key Directories
+### Directory Descriptions
 
-| Path | Purpose | File Examples |
-|------|---------|---------------|
-| `raw/monitoring/pdfs/` | Original WHO PDF bulletins | `OEW37-2025.pdf` |
-| `raw/monitoring/llm_extractions/` | Unprocessed LLM output | `OEW37-2025_gpt-5_1234567890.csv` |
-| `raw/monitoring/rule_based_extractions/` | Unprocessed rule-based output | `OEW37-2025_rule-based_1234567890.csv` |
-| `processed/monitoring/llm_extractions/` | Cleaned, standardized LLM data | `OEW37-2025_gpt-5_1234567890_processed.csv` |
-| `processed/monitoring/rule_based_extractions/` | Cleaned, standardized rule-based data | `OEW37-2025_rule-based_1234567890_processed.csv` |
-| `processed/monitoring/comparisons/` | Discrepancy analysis (2 CSV files) | `OEW37-2025_comparison_summary.csv`<br/>`OEW37-2025_discrepancies.csv` |
-| `processed/monitoring/master_extractions/` | Production-ready master dataset | `OEW37-2025_master.csv`<br/>`OEW37-2025_master_edit.csv` |
-| `processed/logs/` | Execution logs and metadata | Various `.jsonl` files |
+| Path | Purpose |
+|------|---------|
+| `raw/monitoring/pdfs/` | Original WHO PDF bulletins downloaded weekly |
+| `raw/monitoring/llm_extractions/` | Unprocessed CSV output from GPT-5 extraction |
+| `raw/monitoring/rule_based_extractions/` | Unprocessed CSV output from Tabula extraction |
+| `processed/monitoring/llm_extractions/` | Cleaned, standardized LLM data ready for analysis |
+| `processed/monitoring/rule_based_extractions/` | Cleaned, standardized rule-based data ready for analysis |
+| `processed/monitoring/comparisons/` | Discrepancy analysis between LLM and rule-based (2 CSV files per week) |
+| `processed/monitoring/master_extractions/` | Production-ready master dataset (LLM default + analyst edits) |
+| `processed/logs/prompt_logs/` | LLM API execution logs and metadata |
+| `processed/logs/tabular_preprocessing_logs/` | Rule-based extraction execution logs |
 
 ---
 
@@ -183,7 +169,7 @@ graph TD
 
 ### LLM Extraction
 
-**Technology**: OpenAI GPT-4o/GPT-5
+**Technology**: OpenAI GPT-5
 
 **Strengths**:
 - Handles complex table structures

--- a/docs/architecture_for_analysts.md
+++ b/docs/architecture_for_analysts.md
@@ -1,0 +1,546 @@
+# Cholera Data Pipeline: Architecture for Analysts
+
+## Overview
+
+This document explains the cholera data extraction pipeline architecture and workflows designed for data analysts. It covers how data flows through the system, how to review discrepancies, and how to create the "master" dataset for production use.
+
+---
+
+## Table of Contents
+
+- [Pipeline Architecture](#pipeline-architecture)
+- [Data Flow Overview](#data-flow-overview)
+- [Extraction Methods](#extraction-methods)
+- [Comparison & Quality Control](#comparison--quality-control)
+- [Current vs Future Workflows](#current-vs-future-workflows)
+- [Creating the Master Dataset](#creating-the-master-dataset)
+- [Practical Workflows for Analysts](#practical-workflows-for-analysts)
+
+---
+
+## Pipeline Architecture
+
+```mermaid
+graph TB
+    subgraph "1. Data Acquisition"
+        A[WHO Weekly Bulletin PDF<br/>Auto-downloaded weekly]
+    end
+
+    subgraph "2. Parallel Extractions"
+        B[Rule-Based Extraction<br/>Tabula table detection<br/>✅ Fast, free, deterministic<br/>⚠️ Can miss complex tables]
+        C[LLM Extraction<br/>GPT-4/GPT-5<br/>✅ Better accuracy, handles complexity<br/>⚠️ Occasional mistakes, costs money]
+    end
+
+    subgraph "3. Post-Processing"
+        D[Standardization<br/>- Clean numbers<br/>- Normalize country names<br/>- Validate CFR]
+    end
+
+    subgraph "4. Quality Control"
+        E[Automatic Comparison<br/>- Find discrepancies<br/>- Categorize differences<br/>- Generate reports]
+    end
+
+    subgraph "5. Analyst Review"
+        F{Analyst Reviews<br/>Discrepancies}
+        F -->|Identifies correct values| G[Creates Edited Master]
+    end
+
+    subgraph "6. Production Data"
+        H[Master Dataset<br/>master_extractions/<br/>Default: LLM data<br/>Analyst-edited when needed]
+    end
+
+    subgraph "7. End Users"
+        I[Current Email Alerts<br/>Uses rule-based data<br/>🌍 External audience]
+        J[Internal Dashboard<br/>Uses LLM data<br/>🏢 Internal audience only]
+        K[Future Email Alerts<br/>Uses master dataset<br/>📊 Best of both methods]
+    end
+
+    A --> B
+    A --> C
+    B --> D
+    C --> D
+    D --> E
+    E --> F
+    F --> H
+    H --> K
+    B --> I
+    C --> J
+
+    style A fill:#e1f5ff
+    style B fill:#fff4e1
+    style C fill:#fff4e1
+    style D fill:#e8f5e9
+    style E fill:#f3e5f5
+    style F fill:#fff9c4
+    style G fill:#fff9c4
+    style H fill:#c8e6c9
+    style I fill:#ffccbc
+    style J fill:#b2dfdb
+    style K fill:#aed581
+```
+
+---
+
+## Data Flow Overview
+
+### Step-by-Step Process
+
+1. **Weekly PDF Download**
+   - Automated GitHub Action downloads latest WHO cholera bulletin
+   - Stored in blob storage: `raw/monitoring/pdfs/`
+
+2. **Dual Extraction**
+   - **Rule-based**: Uses Tabula library to detect and extract tables
+   - **LLM-based**: Sends PDF to GPT model with structured prompts
+   - Both produce CSV files in `raw/monitoring/llm_extractions/` and `raw/monitoring/rule_based_extractions/`
+
+3. **Post-Processing**
+   - Both extractions standardized using same pipeline
+   - Output: `processed/monitoring/llm_extractions/` and `processed/monitoring/rule_based_extractions/`
+
+4. **Automatic Comparison**
+   - When both processed files exist for same week/year
+   - Generates comparison reports: `processed/monitoring/comparisons/`
+   - Output files:
+     - `OEWxx-YYYY_comparison_summary.csv` - Overview statistics
+     - `OEWxx-YYYY_discrepancies.csv` - Detailed differences
+     - `OEWxx-YYYY_cfr_comparison.csv` - CFR validation
+     - `OEWxx-YYYY_unique_records.csv` - Records found in only one source
+
+---
+
+## Extraction Methods
+
+### Rule-Based Extraction
+
+**Technology**: Tabula (Java-based table detection)
+
+**Strengths**:
+- Fast (no API calls)
+- Free (no LLM costs)
+- Deterministic (same input = same output)
+- Good for well-structured tables
+
+**Weaknesses**:
+- Struggles with complex/merged cells
+- Can miss tables with unusual formatting
+- No contextual understanding
+
+**Use Case**: Currently powers production email alert system
+
+---
+
+### LLM Extraction
+
+**Technology**: OpenAI GPT-4o/GPT-5
+
+**Strengths**:
+- Handles complex table structures
+- Contextual understanding
+- Better overall accuracy
+- Adapts to format changes
+
+**Weaknesses**:
+- Occasional mistakes (hallucination, misinterpretation)
+- Costs money per extraction (~$0.50-2 per document)
+- Non-deterministic (slight variations between runs)
+
+**Use Case**: Internal analysis and review; recommended for master dataset
+
+---
+
+## Comparison & Quality Control
+
+### Automatic Discrepancy Detection
+
+The system automatically compares LLM vs rule-based extractions and categorizes differences:
+
+```mermaid
+flowchart TD
+    A[Both Extractions Complete] --> B[Load Processed Data]
+    B --> C[Align Records<br/>by Country + Event]
+    C --> D{Compare Values}
+
+    D -->|Match| E[✅ Agreement<br/>High confidence]
+    D -->|Differ| F{Categorize<br/>Discrepancy}
+
+    F --> G[Type 1: Comma Issues<br/>Example: 1,234 vs 1234]
+    F --> H[Type 2: Zero vs Non-zero<br/>Example: 0 vs 150]
+    F --> I[Type 3: Magnitude Difference<br/>Example: 100 vs 1000]
+    F --> J[Type 4: Missing Data<br/>One source has null]
+    F --> K[Type 5: Other Differences<br/>Various discrepancies]
+
+    G --> L[Generate Report]
+    H --> L
+    I --> L
+    J --> L
+    K --> L
+
+    L --> M[Upload to Blob Storage<br/>Ready for Analyst Review]
+
+    style E fill:#c8e6c9
+    style F fill:#fff9c4
+    style G fill:#ffccbc
+    style H fill:#ffccbc
+    style I fill:#ffccbc
+    style J fill:#ffccbc
+    style K fill:#ffccbc
+    style M fill:#b2dfdb
+```
+
+### Key Files for Review
+
+When reviewing discrepancies, focus on:
+
+1. **`OEWxx-YYYY_discrepancies.csv`** - Main file showing all differences
+   - Columns: `Country`, `Event`, `Field`, `LLM_value`, `RuleBased_value`, `Discrepancy_category`
+
+2. **`OEWxx-YYYY_comparison_summary.csv`** - High-level statistics
+   - Total records compared
+   - Agreement percentage
+   - Number of discrepancies by type
+
+3. **`OEWxx-YYYY_cfr_comparison.csv`** - Case Fatality Rate validation
+   - Checks if CFR = (Deaths / Total Cases) × 100
+   - Flags inconsistent calculations
+
+---
+
+## Current vs Future Workflows
+
+### Current Production Workflow
+
+```mermaid
+graph LR
+    A[WHO PDF] --> B[Rule-Based<br/>Extraction]
+    B --> C[Post-Process]
+    C --> D[Email Alert<br/>System]
+    D --> E[External<br/>Audience 🌍]
+
+    style A fill:#e1f5ff
+    style B fill:#fff4e1
+    style C fill:#e8f5e9
+    style D fill:#ffccbc
+    style E fill:#ffccbc
+```
+
+**Status**: Stable, production system for external email alerts
+
+---
+
+### New Internal LLM Workflow
+
+```mermaid
+graph LR
+    A[WHO PDF] --> B[LLM<br/>Extraction]
+    B --> C[Post-Process]
+    C --> D[Internal<br/>Dashboard]
+    D --> E[Internal<br/>Audience 🏢]
+
+    style A fill:#e1f5ff
+    style B fill:#fff4e1
+    style C fill:#e8f5e9
+    style D fill:#b2dfdb
+    style E fill:#b2dfdb
+```
+
+**Status**: For internal use only; under evaluation
+
+---
+
+### Future Master Workflow (Recommended)
+
+```mermaid
+graph TB
+    A[WHO PDF] --> B[LLM Extraction]
+    A --> C[Rule-Based Extraction]
+
+    B --> D[Post-Process]
+    C --> D
+
+    D --> E[Generate Comparison]
+    E --> F{Analyst Review}
+
+    F -->|No edits needed| G[Master Dataset<br/>OEWxx-YYYY_master.csv<br/>Defaults to LLM data]
+    F -->|Corrections required| H[Analyst Edits<br/>OEWxx-YYYY_master_edit.csv]
+
+    G --> I[Production Systems]
+    H --> I
+
+    I --> J[Email Alerts]
+    I --> K[Dashboards]
+    I --> L[API Endpoints]
+
+    style A fill:#e1f5ff
+    style F fill:#fff9c4
+    style H fill:#fff9c4
+    style G fill:#c8e6c9
+    style I fill:#aed581
+    style J fill:#ffccbc
+    style K fill:#b2dfdb
+    style L fill:#b2dfdb
+```
+
+**Status**: Planned; combines best of both methods with analyst oversight
+
+---
+
+## Creating the Master Dataset
+
+### Overview
+
+The master dataset (`master_extractions/`) serves as the single source of truth for all production workflows.
+
+### Default Behavior
+
+By default, the master dataset will be populated with **LLM extraction data** because:
+1. Generally more accurate overall
+2. Better handles complex table structures
+3. Fewer systematic errors
+
+### Analyst Edit Workflow
+
+When discrepancies are found, analysts can create corrected versions:
+
+```mermaid
+flowchart LR
+    A[Review Discrepancies<br/>OEWxx-YYYY_discrepancies.csv] --> B{Decision}
+
+    B -->|LLM is correct| C[No action needed<br/>Use default LLM data]
+    B -->|Rule-based is correct| D[Create edited file]
+    B -->|Both wrong| D
+    B -->|Partial corrections| D
+
+    C --> E[master_extractions/<br/>OEWxx-YYYY_master.csv<br/>Symlink to LLM data]
+
+    D --> F[Analyst Creates:<br/>OEWxx-YYYY_master_edit.csv]
+    F --> G[Upload to<br/>master_extractions/]
+
+    E --> H[Production Workflows<br/>Use this data]
+    G --> H
+
+    style A fill:#f3e5f5
+    style B fill:#fff9c4
+    style D fill:#fff9c4
+    style F fill:#fff9c4
+    style H fill:#aed581
+```
+
+### File Naming Convention
+
+| File Type | Pattern | Source | When to Use |
+|-----------|---------|--------|-------------|
+| Default Master | `OEWxx-YYYY_master.csv` | Automatic copy of LLM data | No corrections needed |
+| Edited Master | `OEWxx-YYYY_master_edit.csv` | Analyst-created | Corrections identified |
+
+### Edit Workflow Steps
+
+1. **Download comparison files** from blob storage:
+   ```
+   processed/monitoring/comparisons/OEWxx-YYYY_discrepancies.csv
+   ```
+
+2. **Review discrepancies** and identify corrections needed
+
+3. **Download source files** (LLM and/or rule-based):
+   ```
+   processed/monitoring/llm_extractions/OEWxx-YYYY_gpt-5_*.csv
+   processed/monitoring/rule_based_extractions/OEWxx-YYYY_rule-based_*.csv
+   ```
+
+4. **Create edited master file**:
+   - Start with LLM file as base
+   - Apply corrections from discrepancy review
+   - Save as `OEWxx-YYYY_master_edit.csv`
+
+5. **Upload to master directory**:
+   ```
+   master_extractions/OEWxx-YYYY_master_edit.csv
+   ```
+
+6. **Update production workflows** to prioritize `_edit.csv` files over default `_master.csv`
+
+---
+
+## Practical Workflows for Analysts
+
+### Weekly Review Checklist
+
+**Step 1: Check Extraction Status**
+```bash
+# View recent workflow runs
+gh run list --workflow=llm-extract.yml --limit 5
+gh run list --workflow=rule-based-extract.yml --limit 5
+```
+
+**Step 2: Verify Comparison Generated**
+```bash
+# Check if comparison completed
+gh run list --workflow=post-process-extractions.yml --limit 3
+```
+
+**Step 3: Download Comparison Files**
+- Access blob storage: `processed/monitoring/comparisons/`
+- Download latest week's discrepancies file
+
+**Step 4: Review Discrepancies**
+- Open `OEWxx-YYYY_discrepancies.csv` in Excel/Python
+- Focus on high-impact differences:
+  - Large magnitude differences (Type 3)
+  - Zero vs non-zero (Type 2)
+  - Missing data (Type 4)
+- Ignore comma-only differences (Type 1) - these are formatting
+
+**Step 5: Investigate Root Cause**
+- Download source processed files for both methods
+- Check original PDF if needed
+- Determine which extraction is correct
+
+**Step 6: Create Master File (if edits needed)**
+- Copy LLM file as starting point
+- Apply necessary corrections
+- Save as `OEWxx-YYYY_master_edit.csv`
+- Upload to `master_extractions/` directory
+
+**Step 7: Document Changes**
+- Keep a log of manual corrections
+- Note patterns (helps improve extraction methods)
+
+---
+
+### Common Discrepancy Patterns
+
+#### Pattern 1: Rule-Based Missing Complex Tables
+**Symptoms**: Rule-based has null/empty values; LLM has data
+
+**Example**:
+```
+Country: DRC
+Field: TotalCases
+LLM: 1,234
+Rule-based: null
+```
+
+**Action**: Use LLM value (rule-based likely failed to detect table)
+
+---
+
+#### Pattern 2: LLM Hallucination
+**Symptoms**: LLM has plausible but incorrect value; rule-based has different value or null
+
+**Example**:
+```
+Country: Ethiopia
+Field: Deaths
+LLM: 45
+Rule-based: 54
+PDF shows: 54
+```
+
+**Action**: Use rule-based value or manually verify against PDF
+
+---
+
+#### Pattern 3: Both Methods Wrong
+**Symptoms**: Both extractions differ from PDF source
+
+**Example**:
+```
+Country: Mozambique
+Field: TotalCases
+LLM: 10,000
+Rule-based: 1,000
+PDF shows: 10,500 (includes footnote clarification)
+```
+
+**Action**: Create edited master with correct value (10,500)
+
+---
+
+### Tools & Resources
+
+**Blob Storage Access**:
+- Development: `ds-cholera-pdf-scraper/processed/monitoring/`
+- Comparison reports: `comparisons/`
+- LLM extractions: `llm_extractions/`
+- Rule-based extractions: `rule_based_extractions/`
+
+**GitHub Actions**:
+- Workflow documentation: `.github/WORKFLOWS.md`
+- Trigger manual runs: GitHub UI or `gh` CLI
+
+**Python Analysis**:
+```python
+import pandas as pd
+
+# Load discrepancies
+discrep = pd.read_csv('OEW37-2025_discrepancies.csv')
+
+# Filter high-priority issues
+critical = discrep[
+    (discrep['Discrepancy_category'].isin(['zero_vs_nonzero', 'magnitude_difference']))
+    & (discrep['Field'].isin(['TotalCases', 'Deaths']))
+]
+
+print(f"Found {len(critical)} critical discrepancies requiring review")
+```
+
+---
+
+## Key Decisions for Analysts
+
+### When to Use Rule-Based Data
+- Simple, well-structured tables
+- When LLM shows clear errors (verified against PDF)
+- Cost constraints (no API charges)
+
+### When to Use LLM Data
+- Complex or merged cell tables
+- When rule-based extraction fails/incomplete
+- When accuracy is critical (default recommendation)
+
+### When to Create Edited Master
+- Discrepancies with significant impact (deaths, case counts)
+- Both methods wrong (verified against PDF)
+- Systematic errors detected
+- High-visibility reports
+
+---
+
+## Future Enhancements
+
+### Planned Improvements
+
+1. **Master Dataset Automation**
+   - Automatic population of `master_extractions/`
+   - Default to LLM with confidence scoring
+   - Auto-flag low-confidence extractions for review
+
+2. **Enhanced Comparison Reports**
+   - Confidence scoring for each field
+   - Historical discrepancy trends
+   - Automated suggestions (e.g., "Rule-based historically accurate for this country")
+
+3. **Analyst UI/Dashboard**
+   - Web interface for reviewing discrepancies
+   - Side-by-side PDF viewer with extractions
+   - One-click master file creation
+
+4. **Email Alert Transition**
+   - Migrate from rule-based to master dataset
+   - A/B testing period with both methods
+   - Rollout to external audience after validation period
+
+---
+
+## Support & Contact
+
+For questions about:
+- **Pipeline architecture**: See `.github/WORKFLOWS.md`
+- **Extraction methods**: See `docs/rule-based-extraction.md`
+- **Development setup**: See `docs/development_setup.md`
+
+---
+
+**Document Version**: 1.0
+**Last Updated**: December 2024
+**Maintained By**: Data Science Team

--- a/docs/architecture_for_analysts.md
+++ b/docs/architecture_for_analysts.md
@@ -99,12 +99,64 @@ graph TB
 
 4. **Automatic Comparison**
    - When both processed files exist for same week/year
-   - Generates comparison reports: `processed/monitoring/comparisons/`
+   - Generates comparison CSVs: `processed/monitoring/comparisons/`
    - Output files:
-     - `OEWxx-YYYY_comparison_summary.csv` - Overview statistics
-     - `OEWxx-YYYY_discrepancies.csv` - Detailed differences
-     - `OEWxx-YYYY_cfr_comparison.csv` - CFR validation
-     - `OEWxx-YYYY_unique_records.csv` - Records found in only one source
+     - `OEWxx-YYYY_comparison_summary.csv` - Overview statistics and agreement metrics
+     - `OEWxx-YYYY_discrepancies.csv` - Detailed differences with categorization
+
+---
+
+## Blob Storage Structure
+
+The Azure blob storage is organized with a clear separation between raw and processed data:
+
+```mermaid
+graph TD
+    A[ds-cholera-pdf-scraper/]
+
+    A --> B[raw/]
+    A --> C[processed/]
+
+    B --> B1[monitoring/]
+    B1 --> B1a[pdfs/<br/>Original WHO bulletins<br/>OEWxx-YYYY.pdf]
+    B1 --> B1b[llm_extractions/<br/>Raw LLM output<br/>OEWxx-YYYY_gpt-5_runid.csv]
+    B1 --> B1c[rule_based_extractions/<br/>Raw rule-based output<br/>OEWxx-YYYY_rule-based_runid.csv]
+
+    C --> C1[monitoring/]
+    C --> C2[logs/]
+
+    C1 --> C1a[llm_extractions/<br/>Cleaned LLM data<br/>OEWxx-YYYY_gpt-5_runid_processed.csv]
+    C1 --> C1b[rule_based_extractions/<br/>Cleaned rule-based data<br/>OEWxx-YYYY_rule-based_runid_processed.csv]
+    C1 --> C1c[comparisons/<br/>Discrepancy analysis<br/>OEWxx-YYYY_comparison_summary.csv<br/>OEWxx-YYYY_discrepancies.csv]
+    C1 --> C1d[master_extractions/<br/>Production-ready data<br/>OEWxx-YYYY_master.csv<br/>OEWxx-YYYY_master_edit.csv]
+
+    C2 --> C2a[prompt_logs/<br/>LLM API logs]
+    C2 --> C2b[tabular_preprocessing_logs/<br/>Rule-based extraction logs]
+
+    style A fill:#e1f5ff
+    style B fill:#fff4e1
+    style C fill:#e8f5e9
+    style B1a fill:#ffccbc
+    style B1b fill:#ffccbc
+    style B1c fill:#ffccbc
+    style C1a fill:#c8e6c9
+    style C1b fill:#c8e6c9
+    style C1c fill:#b2dfdb
+    style C1d fill:#aed581
+```
+
+### Key Directories
+
+| Path | Purpose | File Examples |
+|------|---------|---------------|
+| `raw/monitoring/pdfs/` | Original WHO PDF bulletins | `OEW37-2025.pdf` |
+| `raw/monitoring/llm_extractions/` | Unprocessed LLM output | `OEW37-2025_gpt-5_1234567890.csv` |
+| `raw/monitoring/rule_based_extractions/` | Unprocessed rule-based output | `OEW37-2025_rule-based_1234567890.csv` |
+| `processed/monitoring/llm_extractions/` | Cleaned, standardized LLM data | `OEW37-2025_gpt-5_1234567890_processed.csv` |
+| `processed/monitoring/rule_based_extractions/` | Cleaned, standardized rule-based data | `OEW37-2025_rule-based_1234567890_processed.csv` |
+| `processed/monitoring/comparisons/` | Discrepancy analysis (2 CSV files) | `OEW37-2025_comparison_summary.csv`<br/>`OEW37-2025_discrepancies.csv` |
+| `processed/monitoring/master_extractions/` | Production-ready master dataset | `OEW37-2025_master.csv`<br/>`OEW37-2025_master_edit.csv` |
+| `processed/logs/` | Execution logs and metadata | Various `.jsonl` files |
 
 ---
 
@@ -187,21 +239,20 @@ flowchart TD
     style M fill:#b2dfdb
 ```
 
-### Key Files for Review
+### Comparison Output Files
 
-When reviewing discrepancies, focus on:
+The comparison pipeline generates 2 CSV files for analyst review:
 
 1. **`OEWxx-YYYY_discrepancies.csv`** - Main file showing all differences
    - Columns: `Country`, `Event`, `Field`, `LLM_value`, `RuleBased_value`, `Discrepancy_category`
+   - Contains detailed row-by-row comparison of fields where LLM and rule-based differ
+   - Each discrepancy is categorized (comma issues, zero vs non-zero, magnitude difference, etc.)
 
 2. **`OEWxx-YYYY_comparison_summary.csv`** - High-level statistics
    - Total records compared
    - Agreement percentage
-   - Number of discrepancies by type
-
-3. **`OEWxx-YYYY_cfr_comparison.csv`** - Case Fatality Rate validation
-   - Checks if CFR = (Deaths / Total Cases) × 100
-   - Flags inconsistent calculations
+   - Number of discrepancies by type and field
+   - Summary metrics for analyst prioritization
 
 ---
 

--- a/scripts/download_latest_who_pdf.py
+++ b/scripts/download_latest_who_pdf.py
@@ -403,9 +403,14 @@ class LatestWHOPDFDownloader:
 
             soup = BeautifulSoup(driver.page_source, "html.parser")
 
-            # Find all links matching "Week XX: DD to DD Month YYYY"
+            # Find all links matching "Week XX: <date range with year>"
+            # Handles varied WHO date formats:
+            #   "5 to 11 January 2026"
+            #   "29 December to 4 January 2026" (cross-month)
+            #   "28 July - 03 August 2025" (hyphen separator)
+            #   "August 18 to 24 2025" (month-first)
             week_pattern = re.compile(
-                r"Week\s+(\d+):\s+([\d\s]+to[\d\s]+\w+\s+\d{4})", re.IGNORECASE
+                r"Week\s+(\d+):\s+(.+?\d{4})", re.IGNORECASE
             )
 
             for link in soup.find_all("a", href=True):

--- a/scripts/process_raw_extractions.py
+++ b/scripts/process_raw_extractions.py
@@ -209,6 +209,51 @@ def upload_csv_to_blob(
         return None
 
 
+def upload_master_csv(
+    processed_df: pd.DataFrame,
+    week: int,
+    year: int,
+    stage: str = "dev"
+) -> Optional[str]:
+    """
+    Upload LLM processed data as master extraction file.
+
+    Args:
+        processed_df: DataFrame with processed LLM extraction
+        week: Week number
+        year: Year
+        stage: Azure stage (dev/prod)
+
+    Returns:
+        Blob path if successful, None otherwise
+    """
+    try:
+        # Get master extractions path from config
+        blob_base_path = Config.get_blob_paths()["master_extractions"]
+
+        # Create master filename: OEWxx-YYYY_master.csv
+        master_filename = f"OEW{week:02d}-{year}_master.csv"
+        blob_path = f"{blob_base_path}{master_filename}"
+
+        print(f"  📤 Uploading master to {blob_path}...")
+
+        # Upload using stratus
+        stratus.upload_csv_to_blob(
+            df=processed_df,
+            blob_name=blob_path,
+            stage=stage,
+            container_name=Config.BLOB_CONTAINER,
+        )
+
+        print(f"  ✅ Master file uploaded successfully")
+
+        return blob_path
+
+    except Exception as e:
+        print(f"  ❌ Error uploading master: {e}")
+        return None
+
+
 def process_single_extraction(
     blob_name: str,
     filename: str,
@@ -293,6 +338,24 @@ def process_single_extraction(
         if blob_path:
             result['status'] = 'success'
             result['blob_path'] = blob_path
+
+            # Step 6: If this is LLM extraction, also upload as master
+            if source == "llm":
+                # Extract week and year from filename
+                # Expected format: OEWxx-YYYY_gpt-5_runid.csv
+                import re
+                match = re.match(r'OEW(\d{2})-(\d{4})_', filename)
+                if match:
+                    week = int(match.group(1))
+                    year = int(match.group(2))
+
+                    print(f"\n  📋 Creating master dataset for Week {week}, {year}...")
+                    master_path = upload_master_csv(df_processed, week, year, stage)
+                    if master_path:
+                        result['master_path'] = master_path
+                else:
+                    print(f"  ⚠️  Could not extract week/year from filename: {filename}")
+
         else:
             result['error'] = 'Upload failed'
 

--- a/scripts/process_raw_extractions.py
+++ b/scripts/process_raw_extractions.py
@@ -48,6 +48,7 @@ sys.path.insert(0, str(repo_root))
 
 from src.config import Config
 from src.post_processing import apply_post_processing_pipeline, validate_post_processing
+from src.monitoring.comparisons import generate_comparison_reports
 
 
 def list_raw_extractions(source: str, stage: str = "dev") -> List[Dict[str, str]]:
@@ -336,6 +337,16 @@ def main():
         type=int,
         help="Process only files from this year"
     )
+    parser.add_argument(
+        "--generate-comparisons",
+        action="store_true",
+        help="Generate comparison reports (auto-enabled for --source both)"
+    )
+    parser.add_argument(
+        "--no-comparisons",
+        action="store_true",
+        help="Skip comparison generation even when processing both sources"
+    )
 
     args = parser.parse_args()
 
@@ -429,6 +440,109 @@ def main():
             print(f"  - {r['filename']}: {error_msg}")
 
     print()
+
+    # Generate comparisons if requested
+    should_generate_comparisons = (
+        args.generate_comparisons or
+        (args.source == "both" and not args.no_comparisons)
+    )
+
+    if should_generate_comparisons and len(successful) > 0:
+        # Check if we have both LLM and rule-based results
+        llm_results = [r for r in successful if r['source'] == 'llm']
+        rb_results = [r for r in successful if r['source'] == 'rule-based']
+
+        if llm_results and rb_results:
+            print(f"\n{'='*60}")
+            print("GENERATING COMPARISON REPORTS")
+            print(f"{'='*60}")
+            print()
+
+            try:
+                # Determine what to compare based on filters
+                if args.week and args.year:
+                    # Single week comparison
+                    comparison_results = generate_comparison_reports(
+                        week=args.week,
+                        year=args.year,
+                        stage=stage,
+                        correct_gap_fill_errors=args.correct_gap_fill,
+                        output_mode='blob',
+                        verbose=True,
+                    )
+                    print("\n✅ Comparison reports generated successfully!")
+
+                elif args.weeks and args.year:
+                    # Multiple weeks comparison
+                    comparison_results = generate_comparison_reports(
+                        weeks=args.weeks,
+                        year=args.year,
+                        stage=stage,
+                        correct_gap_fill_errors=args.correct_gap_fill,
+                        output_mode='blob',
+                        verbose=True,
+                    )
+                    print("\n✅ Comparison reports generated successfully!")
+
+                else:
+                    # All processed files - compare each week individually
+                    print("ℹ️  Generating comparisons for each week/year...")
+                    print()
+
+                    # Get unique week/year combinations from successful results
+                    week_years = set()
+                    for r in successful:
+                        # Try to extract week/year from filename
+                        # Format: OEW42-2025_source_timestamp.csv
+                        import re
+                        match = re.search(r'OEW(\d+)-(\d{4})', r['filename'])
+                        if match:
+                            week_years.add((int(match.group(1)), int(match.group(2))))
+
+                    comparison_count = 0
+                    for week, year in sorted(week_years):
+                        # Check if both sources exist for this week/year
+                        llm_has = any(
+                            f"OEW{week:02d}-{year}" in r['filename']
+                            for r in llm_results
+                        )
+                        rb_has = any(
+                            f"OEW{week:02d}-{year}" in r['filename']
+                            for r in rb_results
+                        )
+
+                        if llm_has and rb_has:
+                            print(f"Comparing Week {week}, {year}...")
+                            try:
+                                generate_comparison_reports(
+                                    week=week,
+                                    year=year,
+                                    stage=stage,
+                                    correct_gap_fill_errors=args.correct_gap_fill,
+                                    output_mode='blob',
+                                    verbose=False,
+                                )
+                                comparison_count += 1
+                                print(f"  ✅ Comparison complete")
+                            except Exception as e:
+                                print(f"  ❌ Comparison failed: {e}")
+
+                    print(f"\n✅ Generated {comparison_count} comparison reports")
+
+            except Exception as e:
+                print(f"❌ Error generating comparisons: {e}")
+                import traceback
+                traceback.print_exc()
+                # Don't fail the entire script if comparisons fail
+                print("\n⚠️  Continuing despite comparison errors...")
+
+        else:
+            msg_parts = []
+            if not llm_results:
+                msg_parts.append("no LLM results")
+            if not rb_results:
+                msg_parts.append("no rule-based results")
+            print(f"ℹ️  Skipping comparisons: {' and '.join(msg_parts)}")
 
     # Exit code
     sys.exit(0 if len(failed) == 0 else 1)

--- a/scripts/run_llm_extraction_gha.py
+++ b/scripts/run_llm_extraction_gha.py
@@ -552,6 +552,14 @@ def main():
         print("   query = DuckDBCloudQuery()")
         print("   df = query.get_latest_runs(n=5)")
 
+        # Output week/year for GitHub Actions to capture
+        if pdf_info.get('week') and pdf_info.get('year'):
+            print()
+            print("=" * 60)
+            print("EXTRACTION_WEEK=" + str(pdf_info['week']))
+            print("EXTRACTION_YEAR=" + str(pdf_info['year']))
+            print("=" * 60)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/run_rule_based_extraction_gha.py
+++ b/scripts/run_rule_based_extraction_gha.py
@@ -519,6 +519,14 @@ def main():
                     print("📊 Files uploaded to blob:")
                     print(f"   CSV: {run_metadata.csv_blob_path}")
                     print(f"   Log: {run_metadata.log_blob_path}")
+
+                    # Output week/year for GitHub Actions to capture
+                    if run_metadata.week and run_metadata.year:
+                        print()
+                        print("=" * 60)
+                        print("EXTRACTION_WEEK=" + str(run_metadata.week))
+                        print("EXTRACTION_YEAR=" + str(run_metadata.year))
+                        print("=" * 60)
                 else:
                     print("❌ Workflow Failed")
                     print("=" * 60)

--- a/src/config.py
+++ b/src/config.py
@@ -283,6 +283,9 @@ class Config:
             "preprocessing_logs": f"{proj_dir}/processed/logs/tabular_preprocessing_logs/",
             "rule_based_extraction_logs": f"{proj_dir}/processed/logs/",  # For rule_based_extraction_log.jsonl
 
+            # Comparison outputs
+            "comparison_outputs": f"{proj_dir}/processed/monitoring/comparisons/",
+
             # Legacy paths (to be deprecated)
             "historical_pdfs": "historical_pdfs/",
             "weekly_pdfs": "weekly_pdfs/",

--- a/src/config.py
+++ b/src/config.py
@@ -286,6 +286,9 @@ class Config:
             # Comparison outputs
             "comparison_outputs": f"{proj_dir}/processed/monitoring/comparisons/",
 
+            # Master dataset (production-ready)
+            "master_extractions": f"{proj_dir}/processed/monitoring/master_extractions/",
+
             # Legacy paths (to be deprecated)
             "historical_pdfs": "historical_pdfs/",
             "weekly_pdfs": "weekly_pdfs/",

--- a/src/monitoring/__init__.py
+++ b/src/monitoring/__init__.py
@@ -1,0 +1,16 @@
+"""
+Monitoring module for cholera extraction comparisons and validation.
+
+This module provides tools for comparing LLM and rule-based extractions,
+generating comparison reports, and validating data quality.
+"""
+
+from .comparisons import (
+    generate_comparison_reports,
+    BlobExtractionLoader,
+)
+
+__all__ = [
+    'generate_comparison_reports',
+    'BlobExtractionLoader',
+]

--- a/src/monitoring/comparisons.py
+++ b/src/monitoring/comparisons.py
@@ -1,0 +1,776 @@
+"""
+Modular comparison system for cholera data extraction pipelines.
+
+This module provides functions to compare LLM and rule-based extractions,
+generate comparison reports, and upload results to blob storage.
+
+Key Features:
+- Flexible input options (DataFrames, blob paths, specific files)
+- Multiple output modes (blob, local, return)
+- Reuses existing comparison logic from src.batch_run
+- CFR consistency checking
+- CLI interface for standalone use
+
+Usage:
+    # As a module (from scripts or notebooks)
+    from src.monitoring.comparisons import generate_comparison_reports
+
+    results = generate_comparison_reports(
+        week=42,
+        year=2025,
+        stage='dev',
+        output_mode='blob'
+    )
+
+    # From command line
+    python -m src.monitoring.comparisons --week 42 --year 2025 --stage dev
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Any, Tuple
+
+import pandas as pd
+import numpy as np
+import ocha_stratus as stratus
+
+# Add repo root to path
+repo_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(repo_root))
+
+from src.config import Config
+from src.batch_run.analyzer import (
+    analyze_llm_vs_rule_based,
+    categorize_discrepancies,
+    create_summary_statistics,
+)
+from src.batch_run.loader import standardize_column_names
+from src.compare import perform_discrepancy_analysis
+
+# Optional visualization imports
+try:
+    from src.batch_run.visualization import check_cfr_consistency
+    VISUALIZATION_AVAILABLE = True
+except ImportError:
+    VISUALIZATION_AVAILABLE = False
+    check_cfr_consistency = None
+
+
+# =============================================================================
+# BLOB DATA LOADER (adapted from realtime-comparisons branch)
+# =============================================================================
+
+
+class BlobExtractionLoader:
+    """
+    Load extraction results from Azure Blob Storage.
+
+    Supports loading both rule-based and LLM-based extractions from the
+    processed monitoring folders.
+    """
+
+    def __init__(self, stage: str = None):
+        """
+        Initialize blob loader.
+
+        Args:
+            stage: Azure stage (dev/prod), defaults to Config.STAGE or 'dev'
+        """
+        self.stage = stage or os.getenv('STAGE', 'dev')
+        self.container = Config.BLOB_CONTAINER
+        self.proj_dir = Config.BLOB_PROJ_DIR
+        self.account_name = f"imb0chd0{self.stage}"
+
+        # Get SAS token
+        sas_token_key = f"DSCI_AZ_BLOB_{self.stage.upper()}_SAS_WRITE"
+        self.sas_token = os.getenv(sas_token_key)
+
+        if not self.sas_token:
+            # Try read-only token
+            sas_token_key = f"DSCI_AZ_BLOB_{self.stage.upper()}_SAS"
+            self.sas_token = os.getenv(sas_token_key)
+
+        if not self.sas_token:
+            raise ValueError(
+                f"No Azure SAS token found. Set {sas_token_key} environment variable."
+            )
+
+    def list_available_extractions(self, source: str) -> pd.DataFrame:
+        """
+        List all available extractions in blob storage.
+
+        Args:
+            source: "llm" or "rule-based"
+
+        Returns:
+            DataFrame with columns: filename, week, year, blob_name (and model for LLM)
+        """
+        # Get blob prefix from config
+        blob_paths = Config.get_blob_paths()
+        if source == "llm":
+            blob_prefix = blob_paths["processed_llm_extractions"]
+        elif source == "rule-based":
+            blob_prefix = blob_paths["processed_rule_based_extractions"]
+        else:
+            raise ValueError(f"Invalid source: {source}")
+
+        # List blobs using stratus
+        blob_names = stratus.list_container_blobs(
+            name_starts_with=blob_prefix,
+            stage=self.stage,
+            container_name=self.container
+        )
+
+        # Parse blob names to extract metadata
+        extraction_info = []
+        for blob_name in blob_names:
+            if blob_name.endswith('.csv') and '/archive/' not in blob_name:
+                filename = Path(blob_name).name
+
+                # Parse filename like: OEW42-2025_gpt-4o_1234567890.csv
+                # or: OEW42-2025_rule-based_1234567890_processed.csv
+                parts = filename.replace('.csv', '').replace('_processed', '').split('_')
+
+                if parts[0].startswith('OEW'):
+                    week_year = parts[0].replace('OEW', '')
+                    if '-' in week_year:
+                        week, year = week_year.split('-')
+
+                        info = {
+                            'blob_name': blob_name,
+                            'filename': filename,
+                            'week': int(week),
+                            'year': int(year),
+                        }
+
+                        # Add model for LLM extractions
+                        if source == "llm" and len(parts) > 1:
+                            info['model'] = parts[1]
+
+                        # Extract run_id/timestamp (last numeric part)
+                        if len(parts) >= 3:
+                            try:
+                                info['run_id'] = int(parts[-1])
+                            except ValueError:
+                                info['run_id'] = 0
+
+                        extraction_info.append(info)
+
+        if not extraction_info:
+            return pd.DataFrame()
+
+        df = pd.DataFrame(extraction_info)
+        sort_cols = ['year', 'week', 'run_id'] if 'run_id' in df.columns else ['year', 'week']
+        return df.sort_values(sort_cols, ascending=False)
+
+    def load_extraction(
+        self,
+        source: str,
+        week: Optional[int] = None,
+        year: Optional[int] = None,
+        model: Optional[str] = None,
+        blob_path: Optional[str] = None
+    ) -> pd.DataFrame:
+        """
+        Load a specific extraction from blob storage.
+
+        Args:
+            source: "llm" or "rule-based"
+            week: Week number (optional if blob_path provided)
+            year: Year (optional if blob_path provided)
+            model: Model name for LLM extractions (optional, uses first match if None)
+            blob_path: Specific blob path (optional)
+
+        Returns:
+            DataFrame with extraction data
+        """
+        if blob_path:
+            # Load from specific path
+            blob_name = blob_path
+        elif week and year:
+            # Find extraction for this week/year
+            available = self.list_available_extractions(source)
+
+            if source == "llm":
+                matches = available[
+                    (available['week'] == week) &
+                    (available['year'] == year)
+                ]
+                # Filter by model if specified
+                if model and 'model' in matches.columns:
+                    matches = matches[matches['model'] == model]
+            else:
+                matches = available[
+                    (available['week'] == week) &
+                    (available['year'] == year)
+                ]
+
+            if len(matches) == 0:
+                model_msg = f" (model: {model})" if source == "llm" and model else ""
+                raise FileNotFoundError(
+                    f"No {source} extraction found for Week {week}, Year {year}{model_msg}"
+                )
+
+            # Take most recent (first row, already sorted)
+            blob_name = matches.iloc[0]['blob_name']
+        else:
+            raise ValueError("Must provide either (week + year) or blob_path")
+
+        # Load from blob using stratus
+        print(f"  📥 Loading {source} extraction: {Path(blob_name).name}")
+        df = stratus.load_csv_from_blob(
+            blob_name=blob_name,
+            stage=self.stage,
+            container_name=self.container
+        )
+
+        # Standardize column names
+        df = standardize_column_names(df, is_rule_based=(source == "rule-based"))
+
+        # Add metadata if not present
+        if week and 'WeekNumber' not in df.columns:
+            df['WeekNumber'] = week
+        if year and 'Year' not in df.columns:
+            df['Year'] = year
+
+        print(f"  ✅ Loaded {len(df)} records")
+        return df
+
+    def load_bulk(
+        self,
+        source: str,
+        weeks: Optional[List[int]] = None,
+        year: Optional[int] = None,
+        model: str = 'gpt-4o'
+    ) -> pd.DataFrame:
+        """
+        Load multiple extractions in bulk.
+
+        Args:
+            source: "llm" or "rule-based"
+            weeks: List of week numbers (optional)
+            year: Year to filter (required if weeks provided)
+            model: Model name for LLM extractions (default: 'gpt-4o')
+
+        Returns:
+            Combined DataFrame
+        """
+        available = self.list_available_extractions(source)
+
+        if len(available) == 0:
+            raise FileNotFoundError(f"No {source} extractions found")
+
+        # Filter by criteria
+        if weeks and year:
+            available = available[
+                (available['week'].isin(weeks)) & (available['year'] == year)
+            ]
+
+        if source == "llm":
+            available = available[available['model'] == model]
+
+        if len(available) == 0:
+            raise FileNotFoundError(f"No {source} extractions found matching criteria")
+
+        # Get unique week/year combinations and take most recent
+        group_cols = ['week', 'year', 'model'] if source == "llm" else ['week', 'year']
+        unique_weeks = available.groupby(group_cols).first().reset_index()
+
+        # Load each extraction
+        dfs = []
+        for _, row in unique_weeks.iterrows():
+            try:
+                df = self.load_extraction(
+                    source=source,
+                    week=row['week'],
+                    year=row['year'],
+                    model=row.get('model', model)
+                )
+                df['SourceFile'] = row['filename']
+                dfs.append(df)
+            except Exception as e:
+                print(f"  ⚠️  Failed to load {row['filename']}: {e}")
+
+        if not dfs:
+            raise ValueError("Failed to load any extractions")
+
+        combined = pd.concat(dfs, ignore_index=True)
+        print(f"  ✅ Combined {len(dfs)} files ({len(combined)} total records)")
+        return combined
+
+
+# =============================================================================
+# CFR CONSISTENCY CHECKING
+# =============================================================================
+
+
+def compare_cfr_consistency(
+    disc_cat: pd.DataFrame,
+    llm_df: pd.DataFrame,
+    rule_based_df: pd.DataFrame,
+    parameter: str = 'TotalCases',
+    verbose: bool = True
+) -> pd.DataFrame:
+    """
+    Compare CFR consistency between LLM and rule-based for discrepancies.
+
+    Uses the check_cfr_consistency function from visualization module to
+    validate which extraction has values more consistent with reported CFR.
+
+    Args:
+        disc_cat: Categorized discrepancies DataFrame
+        llm_df: LLM extraction data
+        rule_based_df: Rule-based extraction data
+        parameter: Parameter to analyze (default: 'TotalCases')
+        verbose: Print results
+
+    Returns:
+        DataFrame with CFR comparison results
+    """
+    if not VISUALIZATION_AVAILABLE or check_cfr_consistency is None:
+        if verbose:
+            print("  ⚠️  CFR consistency check requires visualization module")
+        return pd.DataFrame()
+
+    # Filter for specific parameter
+    param_disc = disc_cat[disc_cat['Parameter'] == parameter].copy()
+
+    if len(param_disc) == 0:
+        if verbose:
+            print(f"  ℹ️  No {parameter} discrepancies found for CFR analysis")
+        return pd.DataFrame()
+
+    cfr_results = []
+    for _, disc_row in param_disc.iterrows():
+        country = disc_row['Country']
+        event = disc_row['Event']
+        year = disc_row['Year']
+        week = disc_row['Week']
+
+        # Get matching records
+        llm_rec = llm_df[
+            (llm_df['Country'] == country) &
+            (llm_df['Event'] == event) &
+            (llm_df['Year'] == year) &
+            (llm_df['WeekNumber'] == week)
+        ]
+
+        rb_rec = rule_based_df[
+            (rule_based_df['Country'] == country) &
+            (rule_based_df['Event'] == event) &
+            (rule_based_df['Year'] == year) &
+            (rule_based_df['WeekNumber'] == week)
+        ]
+
+        if len(llm_rec) > 0 and len(rb_rec) > 0:
+            # Check CFR consistency
+            llm_rec = check_cfr_consistency(llm_rec)
+            rb_rec = check_cfr_consistency(rb_rec)
+
+            llm_err = llm_rec['cfr_error'].iloc[0] if not pd.isna(llm_rec['cfr_error'].iloc[0]) else 999
+            rb_err = rb_rec['cfr_error'].iloc[0] if not pd.isna(rb_rec['cfr_error'].iloc[0]) else 999
+
+            if llm_err < 999 or rb_err < 999:
+                cfr_results.append({
+                    'Country': country,
+                    'Event': event,
+                    'Year': year,
+                    'Week': week,
+                    'Category': disc_row['Category'],
+                    'LLM_CFR_Error': llm_err,
+                    'RuleBased_CFR_Error': rb_err,
+                    'LLM_Better': llm_err < rb_err
+                })
+
+    cfr_df = pd.DataFrame(cfr_results)
+
+    if verbose and len(cfr_df) > 0:
+        total = len(cfr_df)
+        llm_wins = cfr_df['LLM_Better'].sum()
+        rb_wins = (~cfr_df['LLM_Better']).sum()
+
+        print(f"\n  📊 CFR Consistency Analysis ({parameter}):")
+        print(f"     Total discrepancies with CFR data: {total}")
+        print(f"     LLM has better CFR consistency: {llm_wins} ({llm_wins/total*100:.1f}%)")
+        print(f"     Rule-based has better CFR consistency: {rb_wins} ({rb_wins/total*100:.1f}%)")
+
+    return cfr_df
+
+
+# =============================================================================
+# MAIN COMPARISON FUNCTION
+# =============================================================================
+
+
+def generate_comparison_reports(
+    # Input options (flexible)
+    llm_df: Optional[pd.DataFrame] = None,
+    rule_based_df: Optional[pd.DataFrame] = None,
+    week: Optional[int] = None,
+    year: Optional[int] = None,
+    weeks: Optional[List[int]] = None,
+    llm_blob_path: Optional[str] = None,
+    rule_based_blob_path: Optional[str] = None,
+    # Processing options
+    stage: str = 'dev',
+    model: Optional[str] = None,
+    correct_gap_fill_errors: bool = False,
+    # Output options
+    output_mode: str = 'blob',  # 'blob', 'local', or 'return'
+    output_dir: Optional[str] = None,
+    # Other options
+    verbose: bool = True,
+) -> Dict[str, Any]:
+    """
+    Generate comparison reports between LLM and rule-based extractions.
+
+    This is the main entry point for generating comparison reports. It supports
+    multiple input methods and output modes.
+
+    Input Options (prioritized in this order):
+        1. Direct DataFrames: llm_df and rule_based_df
+        2. Specific blob paths: llm_blob_path and rule_based_blob_path
+        3. Week/year loading: week, year (or weeks, year)
+
+    Output Modes:
+        - 'blob': Upload results to Azure blob storage (default)
+        - 'local': Save to local directory (requires output_dir)
+        - 'return': Just return the results dict (no file output)
+
+    Args:
+        llm_df: LLM extraction DataFrame (optional)
+        rule_based_df: Rule-based extraction DataFrame (optional)
+        week: Single week number to compare (optional)
+        year: Year to compare (optional)
+        weeks: List of week numbers to compare (optional)
+        llm_blob_path: Specific LLM blob path (optional)
+        rule_based_blob_path: Specific rule-based blob path (optional)
+        stage: Azure stage (dev/prod)
+        model: LLM model name (optional, uses first match if None)
+        correct_gap_fill_errors: Apply experimental gap-fill corrections
+        output_mode: Output mode ('blob', 'local', or 'return')
+        output_dir: Local output directory (required if output_mode='local')
+        verbose: Print progress information
+
+    Returns:
+        Dictionary with comparison results:
+            - llm_df: LLM extraction data
+            - rule_based_df: Rule-based extraction data
+            - analysis_results: Detailed analysis by week
+            - combined_discrepancies: All discrepancies combined
+            - discrepancy_categories: Categorized discrepancies
+            - summary_by_week: Summary statistics
+            - cfr_comparison: CFR consistency comparison
+            - unique_records: Records only in one source
+            - output_files: Paths to generated files (if applicable)
+
+    Example:
+        >>> # Compare specific week from blob storage
+        >>> results = generate_comparison_reports(
+        ...     week=42, year=2025, stage='dev', output_mode='blob'
+        ... )
+
+        >>> # Compare using direct DataFrames
+        >>> results = generate_comparison_reports(
+        ...     llm_df=my_llm_data,
+        ...     rule_based_df=my_rb_data,
+        ...     output_mode='local',
+        ...     output_dir='./comparison_results'
+        ... )
+    """
+    if verbose:
+        print("=" * 80)
+        print("COMPARISON REPORT GENERATION")
+        print("=" * 80)
+        print(f"Stage: {stage}")
+        print(f"Model: {model}")
+        print(f"Output mode: {output_mode}")
+        if week:
+            print(f"Week: {week}, Year: {year}")
+        elif weeks:
+            print(f"Weeks: {weeks}, Year: {year}")
+        print("=" * 80)
+        print()
+
+    # Step 1: Load data based on input method
+    loader = None
+
+    if llm_df is not None and rule_based_df is not None:
+        # Direct DataFrames provided
+        if verbose:
+            print("📊 Using provided DataFrames")
+            print(f"  LLM records: {len(llm_df)}")
+            print(f"  Rule-based records: {len(rule_based_df)}")
+            print()
+
+    else:
+        # Need to load from blob storage
+        if verbose:
+            print("📦 Loading data from blob storage...")
+            print()
+
+        loader = BlobExtractionLoader(stage=stage)
+
+        # Load LLM data
+        if llm_blob_path:
+            llm_df = loader.load_extraction('llm', blob_path=llm_blob_path)
+        elif week and year:
+            llm_df = loader.load_extraction('llm', week=week, year=year, model=model)
+        elif weeks and year:
+            llm_df = loader.load_bulk('llm', weeks=weeks, year=year, model=model)
+        else:
+            raise ValueError(
+                "Must provide either: (llm_df + rule_based_df), "
+                "(llm_blob_path + rule_based_blob_path), or (week/weeks + year)"
+            )
+
+        # Load rule-based data
+        if rule_based_blob_path:
+            rule_based_df = loader.load_extraction('rule-based', blob_path=rule_based_blob_path)
+        elif week and year:
+            rule_based_df = loader.load_extraction('rule-based', week=week, year=year)
+        elif weeks and year:
+            rule_based_df = loader.load_bulk('rule-based', weeks=weeks, year=year)
+
+        print()
+
+    # Step 2: Perform analysis
+    if verbose:
+        print("🔍 Analyzing discrepancies...")
+        print()
+
+    analysis_results, combined_discrepancies = analyze_llm_vs_rule_based(
+        llm_df=llm_df,
+        rule_based_df=rule_based_df,
+        correct_gap_fill_errors=correct_gap_fill_errors,
+        verbose=verbose
+    )
+
+    # Step 3: Create summary statistics
+    summary_by_week = create_summary_statistics(analysis_results)
+
+    # Step 4: Categorize discrepancies
+    discrepancy_categories = None
+    if combined_discrepancies is not None and len(combined_discrepancies) > 0:
+        discrepancy_categories = categorize_discrepancies(combined_discrepancies)
+
+        if verbose:
+            print(f"\n📊 Discrepancy breakdown:")
+            print(discrepancy_categories.groupby('Category').size())
+            print()
+
+    # Step 5: CFR consistency comparison
+    cfr_comparison = None
+    if discrepancy_categories is not None and len(discrepancy_categories) > 0:
+        cfr_comparison = compare_cfr_consistency(
+            discrepancy_categories,
+            llm_df,
+            rule_based_df,
+            verbose=verbose
+        )
+
+    # Step 6: Collect unique records (LLM-only and Rule-based-only)
+    unique_records = []
+    for analysis in analysis_results:
+        if analysis['llm_only'] is not None and len(analysis['llm_only']) > 0:
+            llm_only = analysis['llm_only'].copy()
+            llm_only['unique_source'] = 'llm_only'
+            unique_records.append(llm_only)
+
+        if analysis['rule_based_only'] is not None and len(analysis['rule_based_only']) > 0:
+            rb_only = analysis['rule_based_only'].copy()
+            rb_only['unique_source'] = 'rule_based_only'
+            unique_records.append(rb_only)
+
+    unique_records_df = pd.concat(unique_records, ignore_index=True) if unique_records else pd.DataFrame()
+
+    # Step 7: Generate output files based on mode
+    output_files = {}
+
+    if output_mode in ['blob', 'local']:
+        if verbose:
+            print(f"\n💾 Generating output files...")
+            print()
+
+        # Determine filename prefix
+        if week and year:
+            prefix = f"OEW{week:02d}-{year}"
+        elif weeks and year:
+            week_range = f"{min(weeks):02d}-{max(weeks):02d}"
+            prefix = f"OEW{week_range}-{year}"
+        else:
+            prefix = "comparison"
+
+        # Generate files
+        files_to_generate = [
+            (f"{prefix}_comparison_summary.csv", summary_by_week),
+            (f"{prefix}_discrepancies.csv", discrepancy_categories),
+            (f"{prefix}_cfr_comparison.csv", cfr_comparison),
+            (f"{prefix}_unique_records.csv", unique_records_df),
+        ]
+
+        if output_mode == 'blob':
+            # Upload to blob storage
+            blob_base_path = Config.get_blob_paths()["comparison_outputs"]
+
+            for filename, df in files_to_generate:
+                if df is not None and len(df) > 0:
+                    blob_path = f"{blob_base_path}{filename}"
+                    try:
+                        stratus.upload_csv_to_blob(
+                            df=df,
+                            blob_name=blob_path,
+                            stage=stage,
+                            container_name=Config.BLOB_CONTAINER,
+                        )
+                        output_files[filename] = blob_path
+                        if verbose:
+                            print(f"  ✅ Uploaded {filename} to blob storage")
+                    except Exception as e:
+                        if verbose:
+                            print(f"  ❌ Failed to upload {filename}: {e}")
+
+        elif output_mode == 'local':
+            # Save to local directory
+            if not output_dir:
+                raise ValueError("output_dir required when output_mode='local'")
+
+            output_path = Path(output_dir)
+            output_path.mkdir(parents=True, exist_ok=True)
+
+            for filename, df in files_to_generate:
+                if df is not None and len(df) > 0:
+                    file_path = output_path / filename
+                    df.to_csv(file_path, index=False)
+                    output_files[filename] = str(file_path)
+                    if verbose:
+                        print(f"  ✅ Saved {filename}")
+
+        if verbose:
+            print()
+
+    # Step 8: Return results
+    if verbose:
+        print("=" * 80)
+        print("✅ Comparison complete!")
+        print("=" * 80)
+        print()
+
+    return {
+        'llm_df': llm_df,
+        'rule_based_df': rule_based_df,
+        'analysis_results': analysis_results,
+        'combined_discrepancies': combined_discrepancies,
+        'discrepancy_categories': discrepancy_categories,
+        'summary_by_week': summary_by_week,
+        'cfr_comparison': cfr_comparison,
+        'unique_records': unique_records_df,
+        'output_files': output_files,
+    }
+
+
+# =============================================================================
+# COMMAND-LINE INTERFACE
+# =============================================================================
+
+
+def main():
+    """Command-line interface for comparison generation."""
+    parser = argparse.ArgumentParser(
+        description="Generate comparison reports between LLM and rule-based extractions",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Compare specific week
+  python -m src.monitoring.comparisons --week 42 --year 2025 --stage dev
+
+  # Compare specific files
+  python -m src.monitoring.comparisons \\
+    --llm-file ds-cholera-pdf-scraper/processed/monitoring/llm_extractions/OEW42-2025_gpt-4o_123.csv \\
+    --rule-based-file ds-cholera-pdf-scraper/processed/monitoring/rule_based_extractions/OEW42-2025_rb_123.csv \\
+    --output ./results
+
+  # Compare multiple weeks
+  python -m src.monitoring.comparisons --weeks 42 43 44 --year 2025 --stage dev
+
+  # Save to local directory instead of blob
+  python -m src.monitoring.comparisons --week 42 --year 2025 --output ./comparison_results
+        """
+    )
+
+    # Input arguments
+    parser.add_argument('--week', type=int, help='Week number to compare')
+    parser.add_argument('--weeks', type=int, nargs='+', help='Multiple week numbers to compare')
+    parser.add_argument('--year', type=int, help='Year to compare')
+    parser.add_argument('--llm-file', type=str, help='Specific LLM blob path')
+    parser.add_argument('--rule-based-file', type=str, help='Specific rule-based blob path')
+
+    # Processing arguments
+    parser.add_argument('--stage', type=str, default='dev', choices=['dev', 'prod'],
+                        help='Azure stage (default: dev)')
+    parser.add_argument('--model', type=str, default=None,
+                        help='LLM model name (optional, uses first match if not specified)')
+    parser.add_argument('--correct-gap-fill', action='store_true',
+                        help='Apply experimental gap-filling corrections')
+
+    # Output arguments
+    parser.add_argument('--output', type=str,
+                        help='Local output directory (if not specified, uploads to blob)')
+    parser.add_argument('--quiet', action='store_true',
+                        help='Suppress progress output')
+
+    args = parser.parse_args()
+
+    # Validate arguments
+    if not args.llm_file and not args.week and not args.weeks:
+        parser.error("Must provide either --week/--weeks or --llm-file")
+
+    if (args.week or args.weeks) and not args.year:
+        parser.error("--year is required when using --week or --weeks")
+
+    if args.llm_file and not args.rule_based_file:
+        parser.error("Must provide both --llm-file and --rule-based-file")
+
+    # Determine output mode
+    output_mode = 'local' if args.output else 'blob'
+
+    # Run comparison
+    try:
+        results = generate_comparison_reports(
+            week=args.week,
+            year=args.year,
+            weeks=args.weeks,
+            llm_blob_path=args.llm_file,
+            rule_based_blob_path=args.rule_based_file,
+            stage=args.stage,
+            model=args.model,
+            correct_gap_fill_errors=args.correct_gap_fill,
+            output_mode=output_mode,
+            output_dir=args.output,
+            verbose=not args.quiet,
+        )
+
+        # Print summary
+        if not args.quiet:
+            if results['output_files']:
+                print("Generated files:")
+                for filename, path in results['output_files'].items():
+                    print(f"  - {filename}")
+                    if output_mode == 'blob':
+                        print(f"    {path}")
+                    else:
+                        print(f"    {path}")
+
+        sys.exit(0)
+
+    except Exception as e:
+        print(f"❌ Error: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add automatic LLM vs rule-based comparison generation to post-processing workflow
- Auto-populate `master_extractions/` with LLM processed data as analyst baseline
- Fix week/year extraction to use actual PDF metadata instead of current date
- Broaden date regex to handle all WHO bulletin date formats (was stuck on Week 37)
- Add architecture docs for analysts and workflows README

## Key changes
- `src/monitoring/comparisons.py` — new comparison engine
- `scripts/process_raw_extractions.py` — master dataset upload step
- Workflow YAMLs — extract week/year from Python script output, pass through pipeline
- `scripts/download_latest_who_pdf.py` — broader date regex